### PR TITLE
Slight update to embedded citation JSON - now using ADDIN (wdFieldAddin) field type

### DIFF
--- a/csl-citation.txt
+++ b/csl-citation.txt
@@ -6,8 +6,8 @@ objects in documents. The JSON schema references "csl-data.json", which
 describes the CSL citation data object format for CSL processors (documented at
 http://gsl-nagoya-u.net/http/pub/citeproc-doc.html#citation-data-object).
 
-Support for the CSL Embedded Citation Object format is forthcoming in the first
-major release of Mendeley after 0.9.9.
+Support for the CSL Embedded Citation Object format is available in the current
+Mendeley Desktop 1.0-dev2 development preview release.
 
 The CSL citation data object consists of:
 
@@ -45,7 +45,7 @@ The method to embed metadata for citations and bibliographies typically varies
 between word processors. Currently Mendeley uses:
 
 * For Word for Windows: in-text citations and bibliographies are represented by
-  a field code of type "wdFieldQuote" or temporarily represented as a bookmark
+  a field code of type "wdFieldAddin" or temporarily represented as a bookmark
   if exporting to OpenOffice
 * For OpenOffice: in-text citations are of type
   "com.sun.star.text.ReferenceMark", bibliographies are of type
@@ -62,7 +62,7 @@ Citation{970e7ce0-8a21-482e-b7d6-e77794a2d37d}" bit is optional, any text before
 "CSL_CITATION" can be ignored, and newlines have been added for readability):
 
 ---
-Mendeley Citation{970e7ce0-8a21-482e-b7d6-e77794a2d37d} CSL_CITATION
+ADDIN Mendeley Citation{970e7ce0-8a21-482e-b7d6-e77794a2d37d} CSL_CITATION
 {
 	"schema": "https://github.com/citation-style-language/schema/raw/master/csl-citation.json",
 	"citationID":"12rsus7rlj",
@@ -102,5 +102,5 @@ An example of a bibliography field code contents from Mendeley (the "Mendeley
 Bibliography" bit is optional):
 
 ---
-Mendeley Bibliography CSL_BIBLIOGRAPHY
+ADDIN Mendeley Bibliography CSL_BIBLIOGRAPHY
 ---


### PR DESCRIPTION
Update based on current state of implementation in Mendeley Desktop 1.0-dev2
