### PR TITLE
Add a new field for "ahead-of-print"

### DIFF
--- a/csl-data.json
+++ b/csl-data.json
@@ -257,6 +257,9 @@
             "event-date": {
                 "$ref": "date-variable" 
             },
+            "epub-date": {
+                "$ref": "date-variable" 
+            },
             "issued": {
                 "$ref": "date-variable" 
             },

--- a/csl-variables.rnc
+++ b/csl-variables.rnc
@@ -17,6 +17,7 @@ div {
     "accessed"
     | "container"
     | "event-date"
+    | "epub-date"
     | "issued"
     | "original-date"
     | "submitted"


### PR DESCRIPTION
Add support for a new date field, `epub-date`, as described in the xbiblio-devel email thread, [How to encode and process "ahead of print"](http://sourceforge.net/p/xbiblio/mailman/message/34179904/).

As for a name for this new field, @rmzelle had [a few suggestions](https://github.com/citation-style-language/styles/pull/1580#issuecomment-110485204).  I'm partial to "issued-online".
