### PR TITLE
Add Schematron rule to check for uniqueness macro names

### DIFF
--- a/csl.rnc
+++ b/csl.rnc
@@ -18,7 +18,8 @@ dc:rights [
 dc:description [
   "RELAX NG compact schema for the Citation Style Language (CSL)."
 ]
-# Embedded Schematron rules to detect calls to nonexistent macros
+
+# Embedded Schematron rules
 
 sch:ns [ uri = "http://purl.org/net/xbiblio/csl" prefix = "cs" ]
 sch:pattern [
@@ -35,6 +36,13 @@ sch:pattern [
     sch:assert [
       test = "@macro = /cs:style/cs:macro/@name"
       "This macro call has no corresponding macro."
+    ]
+  ]
+  sch:rule [
+    context = "/cs:style/cs:macro"
+    sch:assert [
+      test = "count(/cs:style/cs:macro/@name[. = current()/@name]) = 1"
+      "This macro does not have a unique name."
     ]
   ]
 ]


### PR DESCRIPTION
Coincidentally, two recent pull request failed the Travis tests because of duplicated macro names in the style:

https://github.com/citation-style-language/styles/pull/1818#issuecomment-163950384
https://github.com/citation-style-language/styles/pull/1831#issuecomment-164572121

This hasn’t come up often, but it would be good if the validator would flag it.
