### PR TITLE
Add "table" to locator terms

### DIFF
--- a/csl-terms.rnc
+++ b/csl-terms.rnc
@@ -115,6 +115,7 @@ div {
     | "paragraph"
     | "part"
     | "section"
+    | "table"
     | "sub verbo"
     | "verse"
     |


### PR DESCRIPTION
It should be possible to reference a table as well as figures, etc.