### PR TITLE
Switch licensing over to MIT license

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,3 +145,7 @@ An example of an embedded citation object from Mendeley:
     }
 }
 ```
+
+# Licensing
+
+This repository is released under the MIT license.

--- a/csl-data.rnc
+++ b/csl-data.rnc
@@ -2,7 +2,8 @@ namespace dc = "http://purl.org/dc/elements/1.1/"
 
 dc:title [ "Citation Style Language Data" ]
 dc:creator [ "Bruce D'Arcus" ]
-dc:copyright [ "Bruce D'Arcus, 2009" ]
+dc:rights [ "Copyright 2009-2017 Bruce D'Arcus" ]
+dc:license [ "MIT license" ]
 dc:description [ "A schema for the CSL data model." ]
 include "csl-types.rnc"
 include "csl-variables.rnc"

--- a/csl-repository.rnc
+++ b/csl-repository.rnc
@@ -4,9 +4,8 @@ namespace dc = "http://purl.org/dc/elements/1.1/"
 
 dc:title [ "Extension schema for the Citation Style Language styles repository" ]
 dc:creator [ "Rintze M. Zelle" ]
-dc:rights [
-  "Copyright 2013 Rintze M. Zelle. Permission to freely use, copy and distribute."
-]
+dc:rights [ "Copyright 2013-2017 Rintze Zelle" ]
+dc:license [ "MIT license" ]
 dc:description [
   "Enforces stricter requirements for the styles in the official CSL styles repository."
 ]

--- a/csl.rnc
+++ b/csl.rnc
@@ -13,8 +13,9 @@ dc:creator [ "Simon Kornblith" ]
 bibo:editor [ "Frank Bennett" ]
 bibo:editor [ "Rintze Zelle" ]
 dc:rights [
-  "Copyright 2007-2012 by Frank Bennett, Bruce D'Arcus, Simon Kornblith, and Rintze Zelle. Permission to freely use, copy and distribute."
+  "Copyright 2007-2017 Frank Bennett, Bruce D'Arcus, Simon Kornblith, and Rintze Zelle"
 ]
+dc:license [ "MIT license" ]
 dc:description [
   "RELAX NG compact schema for the Citation Style Language (CSL)."
 ]


### PR DESCRIPTION
As decided in https://github.com/citation-style-language/schema/issues/126.

Probably still want to relicense the actual 0.8.1, 1.0, and 1.0.1 releases as well by making these same changes in release branches.