### PR TITLE
Added comma and semicolon

### DIFF
--- a/csl-terms.rnc
+++ b/csl-terms.rnc
@@ -45,6 +45,8 @@ div {
     | "open-inner-quote"
     | "close-inner-quote"
     | "page-range-delimiter"
+    | "comma"
+    | "semicolon"
     | 
       ## Seasons
       "season-01"


### PR DESCRIPTION
Adding these to Punctuation will enable using different punctuation marks as default in styles for languages like Arabic and Persian. Without the different commas and semicolons, citations are difficult to read and directionality is impacted, adding unneeded complexity in the final editing process.