### PR TITLE
Fix references

### DIFF
--- a/csl-data.rnc
+++ b/csl-data.rnc
@@ -11,7 +11,7 @@ reference = element reference { type, id, uri?, container-uri?, (contributor* & 
 
 ## Types 
 div {
-  type = attribute type { cs-types }
+  type = attribute type { item-types }
 }
 
 ## Identifiers
@@ -31,7 +31,7 @@ div {
 div {
    contributor =
       element contributor {
-         attribute type { cs-names },
+         attribute type { variables.names },
          name-elements
       }
    name-elements =
@@ -47,7 +47,7 @@ div {
 div {
    date =
       element date { 
-         attribute type { cs-dates }, 
+         attribute type { variables.dates }, 
          attribute circa { xsd:boolean }?,
          (date-pattern | date-range)
       }
@@ -76,7 +76,7 @@ div {
 div {
    variable =
       element variable {
-         attribute type { cs-variables },
+         attribute type { variables.standard },
          (simple-variable-pattern | rich-variable-pattern)
       }
    simple-variable-pattern = text


### PR DESCRIPTION
ab8f90ddeb9824028e86a0cd86f6e1e4986d1c6b had renamed the definitions, so the file doesn't work in 1.0.1.