### PR TITLE
Specify draft via $schema in JSON schema

### DIFF
--- a/csl-citation.json
+++ b/csl-citation.json
@@ -1,5 +1,6 @@
 {
-    "description": "JSON schema (draft 3) for CSL citation objects",
+    "description": "JSON schema for CSL citation objects",
+    "$schema" : "http://json-schema.org/draft-03/schema#",
     "id": "https://github.com/citation-style-language/schema/raw/master/csl-citation.json",
     "type": "object",
     "properties": {

--- a/csl-data.json
+++ b/csl-data.json
@@ -1,5 +1,6 @@
 {
-    "description": "JSON schema (draft 3) for CSL input data",
+    "description": "JSON schema for CSL input data",
+    "$schema" : "http://json-schema.org/draft-03/schema#",
     "id": "https://github.com/citation-style-language/schema/raw/master/csl-data.json",
     "type": "array",
     "items": {


### PR DESCRIPTION
The goal is to allow validators to detect which draft to use, without having to hardcode it in downstream applications. For example, I want my application to use the latest CSL Items schema and to continue working even if this repository upgrades to a newer schema draft.