### PR TITLE
Remove duplicate literal types

### DIFF
--- a/csl-data.json
+++ b/csl-data.json
@@ -104,9 +104,6 @@
                                         "boolean" 
                                     ] 
                                 },
-                                "literal" : {
-                                    "type": "string" 
-                                },
                                 "parse-names" : {
                                     "type": [
                                         "string",
@@ -116,7 +113,15 @@
                                 } 
                             },
                             "additionalProperties" : false 
-                        }
+                        },
+                        {
+                            "properties": {
+                                "literal" : {
+                                    "type": "string" 
+                                } 
+                            },
+                            "additionalProperties" : false 
+                        } 
                     ] 
                 } 
             },
@@ -223,10 +228,20 @@
                                     "number",
                                     "boolean" 
                                 ] 
-                            },
+                            }
+                        },
+                        "additionalProperties" : false 
+                    },
+                    {
+                        "properties": {
                             "literal": {
                                 "type": "string" 
-                            },
+                            } 
+                        },
+                        "additionalProperties" : false 
+                    },
+                    {
+                        "properties": {
                             "raw": {
                                 "type": "string" 
                             }

--- a/csl-data.json
+++ b/csl-data.json
@@ -104,6 +104,9 @@
                                         "boolean" 
                                     ] 
                                 },
+                                "literal" : {
+                                    "type": "string" 
+                                },
                                 "parse-names" : {
                                     "type": [
                                         "string",
@@ -113,15 +116,7 @@
                                 } 
                             },
                             "additionalProperties" : false 
-                        },
-                        {
-                            "properties": {
-                                "literal" : {
-                                    "type": "string" 
-                                } 
-                            },
-                            "additionalProperties" : false 
-                        } 
+                        }
                     ] 
                 } 
             },
@@ -228,20 +223,10 @@
                                     "number",
                                     "boolean" 
                                 ] 
-                            }
-                        },
-                        "additionalProperties" : false 
-                    },
-                    {
-                        "properties": {
+                            },
                             "literal": {
                                 "type": "string" 
-                            } 
-                        },
-                        "additionalProperties" : false 
-                    },
-                    {
-                        "properties": {
+                            },
                             "raw": {
                                 "type": "string" 
                             }

--- a/csl-data.json
+++ b/csl-data.json
@@ -116,15 +116,7 @@
                                 } 
                             },
                             "additionalProperties" : false 
-                        },
-                        {
-                            "properties": {
-                                "literal" : {
-                                    "type": "string" 
-                                } 
-                            },
-                            "additionalProperties" : false 
-                        } 
+                        }
                     ] 
                 } 
             },
@@ -240,15 +232,7 @@
                             }
                         },
                         "additionalProperties" : false 
-                    },
-                    {
-                        "properties": {
-                            "literal": {
-                                "type": "string" 
-                            } 
-                        },
-                        "additionalProperties" : false 
-                    } 
+                    }
                 ] 
             },
             "container": {


### PR DESCRIPTION
Closes https://github.com/citation-style-language/schema/issues/154

I verified the following executed without error (but have not done further testing):

```python
import jsonref
import jsonschema
url = 'https://github.com/dhimmel/schema/raw/01d112e0ba606c4f61fcc9e27e4f623f5aad8da6/csl-data.json'
schema = jsonref.load_uri(url, jsonschema=True)
jsonschema.Draft3Validator.check_schema(schema)
```

Another question is whether there is a larger simplification that can be made. Should type remain a list in these instances?