### PR TITLE
add cs:intext element

### DIFF
--- a/csl.rnc
+++ b/csl.rnc
@@ -13,7 +13,7 @@ dc:creator [ "Simon Kornblith" ]
 bibo:editor [ "Frank Bennett" ]
 bibo:editor [ "Rintze Zelle" ]
 dc:rights [
-  "Copyright 2007-2018 Citation Style Language and contributors"
+  "Copyright 2007-2020 Citation Style Language and contributors"
 ]
 dc:license [ "MIT license" ]
 dc:description [
@@ -66,6 +66,7 @@ div {
       (style.locale*
        & style.macro*
        & style.citation
+       & style.intext?
        & style.bibliography?)
     }
   
@@ -401,6 +402,14 @@ div {
     ## Use to describe the formatting of citations.
     element cs:citation { citation.options, sort?, citation.layout }
   
+  style.intext =
+
+    ## Defines the author-only rendering for assembly of a textual citations
+    ## (for example, "Doe [3]" or "Doe (2018)"), where the output expectations
+    ## for in-text authors are different than the default citation rendering;
+    ## for example, in APA, or numeric styles.
+    element cs:intext { citation.options, sort?, citation.layout }
+
   style.bibliography =
     
     ## Use to describe the formatting of the bibliography.


### PR DESCRIPTION
This adds an optional cs:intext element to support definition of AuthorOnly rendering required to assemble intext (aka narrative, or textual) citations. 

It addresses #141 by implementing the syntax used by @fbennett in his citeproc-js [intext-element](https://github.com/Juris-M/citeproc-js/tree/intext-element) branch.

Note: 

1. this change does not require changes to existing styles, nor should it break processors, which can just ignore the new element
2. there is still a question about what the spec should say about how this new element works with number and note styles. In author-date, authors get suppressed when rendered in-text. But I'm not sure in the other style classes, but we can leave that for a documentation PR