### PR TITLE
add new cs:intext element

### DIFF
--- a/csl.rnc
+++ b/csl.rnc
@@ -72,6 +72,7 @@ div {
       (style.locale*
        & style.macro*
        & style.citation
+       & style.intext?
        & style.bibliography?)
     }
   
@@ -406,6 +407,14 @@ div {
     
     ## Use to describe the formatting of citations.
     element cs:citation { citation.options, sort?, citation.layout }
+
+  style.intext =
+
+    ## Defines the author-only rendering for assembly of a textual citations
+    ## (for example, "Doe [3]" or "Doe (2018)"), where the output expectations
+    ## for in-text authors are different than the default citation rendering;
+    ## for example, in APA, or numeric styles.
+    element cs:intext { citation.options, sort?, citation.layout }
   
   style.bibliography =
     


### PR DESCRIPTION
Supports definition of AuthorOnly rendering required to assemble
intext (aka narrative, or textual) citations.

Closes #141.