### PR TITLE
Remove deprecated attribute values

### DIFF
--- a/schemas/styles/csl.rnc
+++ b/schemas/styles/csl.rnc
@@ -164,10 +164,6 @@ div {
         |
           ## URI of style documentation.
           "documentation"
-        |
-          ## Obsolete for independent styles. Will be disallowed with
-          ## CSL 1.1.
-          "independent-parent"
       },
       info-text
     }
@@ -187,10 +183,6 @@ div {
         |
           ## URI of style documentation.
           "documentation"
-        |
-          ## Obsolete for dependent styles. Will be disallowed with CSL
-          ## 1.1.
-          "template"
       },
       info-text
     }


### PR DESCRIPTION
This removes the deprecated "template" and "independent-parent"
attribute values, and closes #58.