### PR TITLE
Add issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,25 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: ''
+labels: enhancement
+assignees: ''
+
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. 
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context about the feature request here. 
+
+*For changes to the CSL RNC schemas, this should include links to citation style guides.* It's better to include links to more than one style guide, and no more than five, for us to assess how widely needed this feature might be.
+
+- [MSRI style guide](https://www.mdpi.com/authors/references) 
+


### PR DESCRIPTION
Not really sure exactly what these should be in the end, but this is a start.

It's designed to address the biggest thing historically missing from issue requests (missing context, including style guide links). 

Note, though, I only tweaked the default template, so not sure.

Please review this "feature request" template, and also weigh in on if you think we need others (like "bug report"), and if so, what the content should be.