### PR TITLE
Update csl-citation.json

### DIFF
--- a/schemas/input/csl-citation.json
+++ b/schemas/input/csl-citation.json
@@ -28,7 +28,7 @@
                         ]
                     },
                     "itemData": {
-                        "$ref": "csl-data.json/#/items" 
+                        "$ref": "csl-data.json#/items" 
                     },
                     "prefix": {
                         "type": "string" 


### PR DESCRIPTION
The way the reference fo `itemData` is currently written `csl-data.json` is assumed to be a folder. This breaks dereferencing in json schema tools. Fix is simple, remove the extra `/` and access items relative to `csl-data.json`