### PR TITLE
Add translated-title

### DIFF
--- a/schemas/input/csl-data.json
+++ b/schemas/input/csl-data.json
@@ -379,6 +379,12 @@
       "title-short": {
         "type": "string"
       },
+      "translated-title": {
+        "type": "string"
+      },
+      "translated-title-short": {
+        "type": "string"
+      },
       "URL": {
         "type": "string"
       },

--- a/schemas/styles/csl-variables.rnc
+++ b/schemas/styles/csl-variables.rnc
@@ -106,6 +106,8 @@ div {
     | "status"
     | "title"
     | "title-short"
+    | "translated-title"
+    | "translated-title-short"
     | "URL"
     | "version"
     | "volume-title"


### PR DESCRIPTION
# Description

`translated-title` is a translation of a different-lanugage title (e.g., to provide an English translation of a Spanish title in an English-locale bibliography). For example, this is the APA format for an item with a non-English title:
Chaves-Morillo, V., Gómez Calero, C., Fernández-Muñoz, J. J., Toledano-Muñoz, A., Fernández-Huete, J., Martínez-Monge, N., Palacios-Ceña, D., & Peñacoba-Puente, C. (2017). La anosmia neurosensorial: Relación entre subtipo, tiempo de reconocimiento y edad [Sensorineural anosmia: Relationship between subtype, recognition time, and age]. _Clínica y Salud, 28_(3), 155–161. https://doi.org/10.1016/j.clysa.2017.04.002

This is not intended to provide full multilingual support ala CSLm.


Addresses the `translated-title` discussion here: https://github.com/citation-style-language/zotero-bits/issues/50

## Type of change

- [x] Variable Addition (adds a new variable or type string)