### PR TITLE
Add curator variable

### DIFF
--- a/schemas/input/csl-data.json
+++ b/schemas/input/csl-data.json
@@ -115,6 +115,12 @@
           "$ref": "#/definitions/name-variable"
         }
       },
+      "curator": {
+        "type": "array",
+        "items": {
+          "$ref": "#/definitions/name-variable"
+        }
+      },
       "director": {
         "type": "array",
         "items": {

--- a/schemas/styles/csl-variables.rnc
+++ b/schemas/styles/csl-variables.rnc
@@ -29,6 +29,7 @@ div {
     | "composer"
     | "container-author"
     | "contributor"
+    | "curator"
     | "director"
     | "editor"
     | "editorial-director"


### PR DESCRIPTION
# Description

The curator of a collection or exhibition. Used when citing an exhibition catalog or an entry in such a catalog.

https://forums.zotero.org/discussion/17338
https://forums.zotero.org/discussion/13142/exhibition-catalogue
https://forums.zotero.org/discussion/comment/344317#Comment_344317

## Type of change

- [X] Variable Addition (adds a new variable or type string)
- [X] This change requires a documentation update
