### PR TITLE
adds citekey variable to csl-data.json and csl-variables.rnc

### DIFF
--- a/schemas/input/csl-data.json
+++ b/schemas/input/csl-data.json
@@ -58,6 +58,9 @@
       "id": {
         "type": ["string", "number"]
       },
+      "citekey": {
+        "type": "string"
+      },
       "categories": {
         "type": "array",
         "items": {

--- a/schemas/input/csl-data.json
+++ b/schemas/input/csl-data.json
@@ -58,7 +58,7 @@
       "id": {
         "type": ["string", "number"]
       },
-      "citekey": {
+      "citation-key": {
         "type": "string"
       },
       "categories": {

--- a/schemas/styles/csl-variables.rnc
+++ b/schemas/styles/csl-variables.rnc
@@ -3,13 +3,13 @@ namespace a = "http://relaxng.org/ns/compatibility/annotations/1.0"
 
 ## Variables
 div {
-  
+
   ## All variables
   variables = variables.dates | variables.names | variables.standard
-  
+
   ## Standard variables
   variables.standard = variables.numbers | variables.strings
-  
+
   ## Date variables
   variables.dates =
     "accessed"
@@ -19,7 +19,7 @@ div {
     | "issued"
     | "original-date"
     | "submitted"
-  
+
   ## Name variables
   variables.names =
     "author"
@@ -43,7 +43,7 @@ div {
     | "recipient"
     | "reviewed-author"
     | "translator"
-  
+
   ## Number variables
   variables.numbers =
     "chapter-number"
@@ -62,7 +62,7 @@ div {
     | "printing"
     | "supplement"
     | "volume"
-  
+
   ## String variables
   variables.strings =
     "abstract"
@@ -74,6 +74,7 @@ div {
     | "authority"
     | "call-number"
     | "citation-label"
+    | "citekey"
     | "collection-title"
     | "container-title"
     | "container-title-short"

--- a/schemas/styles/csl-variables.rnc
+++ b/schemas/styles/csl-variables.rnc
@@ -3,13 +3,13 @@ namespace a = "http://relaxng.org/ns/compatibility/annotations/1.0"
 
 ## Variables
 div {
-
+  
   ## All variables
   variables = variables.dates | variables.names | variables.standard
-
+  
   ## Standard variables
   variables.standard = variables.numbers | variables.strings
-
+  
   ## Date variables
   variables.dates =
     "accessed"
@@ -19,7 +19,7 @@ div {
     | "issued"
     | "original-date"
     | "submitted"
-
+  
   ## Name variables
   variables.names =
     "author"
@@ -43,7 +43,7 @@ div {
     | "recipient"
     | "reviewed-author"
     | "translator"
-
+  
   ## Number variables
   variables.numbers =
     "chapter-number"
@@ -62,7 +62,7 @@ div {
     | "printing"
     | "supplement"
     | "volume"
-
+  
   ## String variables
   variables.strings =
     "abstract"

--- a/schemas/styles/csl-variables.rnc
+++ b/schemas/styles/csl-variables.rnc
@@ -74,7 +74,7 @@ div {
     | "authority"
     | "call-number"
     | "citation-label"
-    | "citekey"
+    | "citation-key"
     | "collection-title"
     | "container-title"
     | "container-title-short"


### PR DESCRIPTION
## Description

This adds `citekey` to csl-data.json and csl-variables.rnc.

This should make switching from word-processors to plain text based systems (pandoc, latex) easier.

Closes #243

## Question
Do we need to add this also to csl-citation.json in addition to `id` [here](https://github.com/citation-style-language/schema/blob/68dff7c3d9906a7dc915b06409353e5ad28b8506/schemas/input/csl-citation.json#L24).

## Type of change

Please delete options that are not relevant.

- [X] Variable Addition (adds a new variable or type string)
- [X] This change requires a documentation update

## Checklist

- [X] If I modified any of the schema files, I have run trang and/or prettier on the files, per [CONTRIBUTING](https://github.com/citation-style-language/schema/blob/master/CONTRIBUTING.md)
- [X] I have performed a self-review of my own code
- [ ] I have included suggested corresponding changes to the documentation (if relevant)