### PR TITLE
Deprecate sentence case

### DIFF
--- a/schemas/styles/csl.rnc
+++ b/schemas/styles/csl.rnc
@@ -1093,7 +1093,7 @@ div {
         ## Renders text in title case.
         "title"
       | 
-        ## Renders text in sentence case.
+        ## Renders text in sentence case. Deprecated.
         "sentence"
     }?
 }


### PR DESCRIPTION
We expect data to be input in sentence case because reliably converting to sentence case isn't possible without BibTeX-style escaping. Will remove in v1.1.