### PR TITLE
Item type terms

### DIFF
--- a/schemas/styles/csl-terms.rnc
+++ b/schemas/styles/csl-terms.rnc
@@ -7,11 +7,14 @@ div {
     terms.gender-assignable
     | terms.gender-variants
     | terms.locator
-    | 
+    |
+      ## Item types
+      item-types
+    |
       ## Contributor roles
       variables.names
     | "editortranslator"
-    | 
+    |
       ## Miscellaneous terms
       "accessed"
     | "ad"
@@ -42,26 +45,26 @@ div {
     | "retrieved"
     | "scale"
     | "version"
-    | 
+    |
       ## Punctuation
       "open-quote"
     | "close-quote"
     | "open-inner-quote"
     | "close-inner-quote"
     | "page-range-delimiter"
-    | 
+    |
       ## Seasons
       "season-01"
     | "season-02"
     | "season-03"
     | "season-04"
-    | 
+    |
       ## (legacy; remove in CSL 1.1)
       category.field
-  
+
   ## Terms to which a gender may be assigned
   terms.gender-assignable =
-    
+
     ## Months
     "month-01"
     | "month-02"
@@ -77,15 +80,15 @@ div {
     | "month-12"
     | terms.non-locator-number-variables
     | terms.locator-number-variables
-  
+
   ## Terms for which gender variants may be specified
   terms.gender-variants = terms.ordinals | terms.long-ordinals
   terms.ordinals =
-    
+
     ## Ordinals
     xsd:string { pattern = "ordinal(-\d{2})?" }
   terms.long-ordinals =
-    
+
     ## Long ordinals
     "long-ordinal-01"
     | "long-ordinal-02"
@@ -97,15 +100,15 @@ div {
     | "long-ordinal-08"
     | "long-ordinal-09"
     | "long-ordinal-10"
-  
+
   ## Locators
   terms.locator =
     terms.locator.testable
-    | 
+    |
       ## "sub verbo" is recognized as "sub" & "verbo" in attribute lists; term
       ## should be renamed to "sub-verbo"
       "sub verbo"
-  
+
   ## Locator terms that can be tested with the "locator" conditional
   ## ("sub verbo" can be tested with "sub-verbo")
   terms.locator.testable =
@@ -133,10 +136,10 @@ div {
     | "title"
     | "verse"
     | terms.locator-number-variables
-  
+
   ## Locator terms with matching number variables
   terms.locator-number-variables = "issue" | "volume"
-  
+
   ## Non-locator terms accompanying number variables
   terms.non-locator-number-variables =
     "chapter-number"

--- a/schemas/styles/csl-terms.rnc
+++ b/schemas/styles/csl-terms.rnc
@@ -7,9 +7,7 @@ div {
     terms.gender-assignable
     | terms.gender-variants
     | terms.locator
-    | 
-      ## Item types
-      item-types
+    | item-types
     | 
       ## Contributor roles
       variables.names

--- a/schemas/styles/csl-terms.rnc
+++ b/schemas/styles/csl-terms.rnc
@@ -7,14 +7,14 @@ div {
     terms.gender-assignable
     | terms.gender-variants
     | terms.locator
-    |
+    | 
       ## Item types
       item-types
-    |
+    | 
       ## Contributor roles
       variables.names
     | "editortranslator"
-    |
+    | 
       ## Miscellaneous terms
       "accessed"
     | "ad"
@@ -45,26 +45,26 @@ div {
     | "retrieved"
     | "scale"
     | "version"
-    |
+    | 
       ## Punctuation
       "open-quote"
     | "close-quote"
     | "open-inner-quote"
     | "close-inner-quote"
     | "page-range-delimiter"
-    |
+    | 
       ## Seasons
       "season-01"
     | "season-02"
     | "season-03"
     | "season-04"
-    |
+    | 
       ## (legacy; remove in CSL 1.1)
       category.field
-
+  
   ## Terms to which a gender may be assigned
   terms.gender-assignable =
-
+    
     ## Months
     "month-01"
     | "month-02"
@@ -80,15 +80,15 @@ div {
     | "month-12"
     | terms.non-locator-number-variables
     | terms.locator-number-variables
-
+  
   ## Terms for which gender variants may be specified
   terms.gender-variants = terms.ordinals | terms.long-ordinals
   terms.ordinals =
-
+    
     ## Ordinals
     xsd:string { pattern = "ordinal(-\d{2})?" }
   terms.long-ordinals =
-
+    
     ## Long ordinals
     "long-ordinal-01"
     | "long-ordinal-02"
@@ -100,15 +100,15 @@ div {
     | "long-ordinal-08"
     | "long-ordinal-09"
     | "long-ordinal-10"
-
+  
   ## Locators
   terms.locator =
     terms.locator.testable
-    |
+    | 
       ## "sub verbo" is recognized as "sub" & "verbo" in attribute lists; term
       ## should be renamed to "sub-verbo"
       "sub verbo"
-
+  
   ## Locator terms that can be tested with the "locator" conditional
   ## ("sub verbo" can be tested with "sub-verbo")
   terms.locator.testable =
@@ -136,10 +136,10 @@ div {
     | "title"
     | "verse"
     | terms.locator-number-variables
-
+  
   ## Locator terms with matching number variables
   terms.locator-number-variables = "issue" | "volume"
-
+  
   ## Non-locator terms accompanying number variables
   terms.non-locator-number-variables =
     "chapter-number"


### PR DESCRIPTION
## Description

Some style require descriptive terms added for certain item types. This poses challenges for localization. This adds a term for every item type to `csl-terms.rnc`.

Fixes https://github.com/citation-style-language/schema/issues/178

See also https://github.com/citation-style-language/zotero-bits/issues/70


## Type of change

Please delete options that are not relevant.

- [X] Term addition (adds a new terms
- [X] This change requires a documentation update

## Checklist

- [X] I have installed the repo [pre-commit hook](https://github.com/citation-style-language/schema/blob/master/CONTRIBUTING.md#pre-commit-hooks); if not, and I have modified any of the schema files, I have run trang and/or prettier on the files, per [CONTRIBUTING](https://github.com/citation-style-language/schema/blob/master/CONTRIBUTING.md)
- [X] I have performed a self-review of my own code
- [X] I have included suggested corresponding changes to the documentation (if relevant)
