### PR TITLE
Add new cs:condition element to choose

### DIFF
--- a/schemas/styles/csl-choose.rnc
+++ b/schemas/styles/csl-choose.rnc
@@ -1,0 +1,85 @@
+namespace a = "http://relaxng.org/ns/compatibility/annotations/1.0"
+namespace cs = "http://purl.org/net/xbiblio/csl"
+
+
+## cs:choose - Conditional Statements"
+div {
+  rendering-element.choose =
+    
+    ## Use to conditionally render rendering elements.
+    element cs:choose { choose.if, choose.else-if*, choose.else? }
+  
+  ## When specifying conditions, we allow either the attribute syntax or the element-based one.
+  choose.condition =
+    condition.atts
+    | element cs:conditions { match, condition.elem+ }
+  choose.if = element cs:if { choose.condition, rendering-element* }
+  choose.else-if =
+    element cs:else-if { choose.condition+, rendering-element* }
+  choose.else = element cs:else { rendering-element+ }
+  
+  ## This element allows for more complex conditional logic; for 
+  ## example, if you need to specify mixed "match" rules.
+  condition.elem = element cs:condition { match?, condition.atts }
+  condition.atts =
+    
+    ## If used, the element content is only rendered if it disambiguates two
+    ## otherwise identical citations. This attempt at disambiguation is only
+    ## made after all other disambiguation methods have failed.
+    [ a:defaultValue = "true" ] attribute disambiguate { "true" }
+    | 
+      ## Tests whether the given variables contain numeric text.
+      attribute is-numeric {
+        list { variables+ }
+      }
+    | 
+      ## Tests whether the given date variables contain approximate dates.
+      attribute is-uncertain-date {
+        list { variables.dates+ }
+      }
+    | 
+      ## Tests whether the locator matches the given locator types.
+      attribute locator {
+        list { (terms.locator.testable | "sub-verbo")+ }
+      }
+    | 
+      ## Tests whether the cite position matches the given positions.
+      attribute position {
+        list {
+          ("first"
+           | "subsequent"
+           | "ibid"
+           | "ibid-with-locator"
+           | "near-note")+
+        }
+      }
+    | 
+      ## Tests whether the item matches the given types.
+      attribute type {
+        list { item-types+ }
+      }
+    | 
+      ## Tests whether the default ("long") forms of the given variables
+      ## contain non-empty values.
+      attribute variable {
+        list { variables+ }
+      }
+  match =
+    
+    ## Set the testing logic.
+    [ a:defaultValue = "all" ]
+    attribute match {
+      
+      ## Element only tests "true" when all conditions test "true" for all
+      ## given test values.
+      "all"
+      | 
+        ## Element tests "true" when any condition tests "true" for any given
+        ## test value.
+        "any"
+      | 
+        ## Element only tests "true" when none of the conditions test "true"
+        ## for any given test value.
+        "none"
+    }?
+}

--- a/schemas/styles/csl.rnc
+++ b/schemas/styles/csl.rnc
@@ -21,6 +21,7 @@ dc:description [
 ]
 
 ## Subparts of the CSL schema
+include "csl-choose.rnc"
 include "csl-terms.rnc"
 include "csl-types.rnc"
 include "csl-variables.rnc"
@@ -1062,85 +1063,6 @@ div {
       [ a:defaultValue = "ascending" ]
       attribute sort { "ascending" | "descending" }?
     }
-}
-# ==============================================================================
-
-## cs:choose - Conditional Statements"
-div {
-  rendering-element.choose =
-    
-    ## Use to conditionally render rendering elements.
-    element cs:choose { choose.if, choose.else-if*, choose.else? }
-
-  choose.if = element cs:if { condition+, match, rendering-element* }
-
-  choose.else-if =
-    element cs:else-if { condition+, match, rendering-element* }
-
-  choose.else = element cs:else { rendering-element+ }
-
-  condition =
-    
-    ## If used, the element content is only rendered if it disambiguates two
-    ## otherwise identical citations. This attempt at disambiguation is only
-    ## made after all other disambiguation methods have failed.
-    [ a:defaultValue = "true" ] attribute disambiguate { "true" }
-    | 
-      ## Tests whether the given variables contain numeric text.
-      attribute is-numeric {
-        list { variables+ }
-      }
-    | 
-      ## Tests whether the given date variables contain approximate dates.
-      attribute is-uncertain-date {
-        list { variables.dates+ }
-      }
-    | 
-      ## Tests whether the locator matches the given locator types.
-      attribute locator {
-        list { (terms.locator.testable | "sub-verbo")+ }
-      }
-    | 
-      ## Tests whether the cite position matches the given positions.
-      attribute position {
-        list {
-          ("first"
-           | "subsequent"
-           | "ibid"
-           | "ibid-with-locator"
-           | "near-note")+
-        }
-      }
-    | 
-      ## Tests whether the item matches the given types.
-      attribute type {
-        list { item-types+ }
-      }
-    | 
-      ## Tests whether the default ("long") forms of the given variables
-      ## contain non-empty values.
-      attribute variable {
-        list { variables+ }
-      }
-
-  match =
-    
-    ## Set the testing logic.
-    [ a:defaultValue = "all" ]
-    attribute match {
-      
-      ## Element only tests "true" when all conditions test "true" for all
-      ## given test values.
-      "all"
-      | 
-        ## Element tests "true" when any condition tests "true" for any given
-        ## test value.
-        "any"
-      | 
-        ## Element only tests "true" when none of the conditions test "true"
-        ## for any given test value.
-        "none"
-    }?
 }
 # ==============================================================================
 


### PR DESCRIPTION
## Description

This adds a modified version of the CSL-M condition element as an option
to configure more complex conditional rules.

Also splits off the cs:choose section into a separate file.

Closes #255

## RFC

Could people please test this, both the actual code, and also the docstrings, in a validating edtior (like Atom), and post feedback?

Will it be totally clear for style authors how this would work if we merge this?

## Type of change

- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] This change requires a documentation update
