### PR TITLE
Add event type

### DIFF
--- a/schemas/styles/csl-types.rnc
+++ b/schemas/styles/csl-types.rnc
@@ -19,6 +19,7 @@ div {
     | "entry"
     | "entry-dictionary"
     | "entry-encyclopedia"
+    | "event"
     | "figure"
     | "graphic"
     | "hearing"


### PR DESCRIPTION
## Description

Add type `event` for citations directly to exhibitions, conferences, etc.

Fixes # https://github.com/citation-style-language/schema/issues/208#issuecomment-646954989

## Type of change

- [X] Variable addition (adds a new variable or type string)
- [X] This change requires a documentation update