### PR TITLE
input: Add related-item modelling #268

### DIFF
--- a/schemas/input/csl-data.json
+++ b/schemas/input/csl-data.json
@@ -4,451 +4,7 @@
   "$id": "https://resource.citationstyles.org/schema/latest/input/json/csl-data.json",
   "type": "array",
   "items": {
-    "type": "object",
-    "properties": {
-      "type": {
-        "type": "string",
-        "enum": [
-          "article",
-          "article-journal",
-          "article-magazine",
-          "article-newspaper",
-          "bill",
-          "book",
-          "broadcast",
-          "chapter",
-          "classic",
-          "collection",
-          "dataset",
-          "document",
-          "entry",
-          "entry-dictionary",
-          "entry-encyclopedia",
-          "figure",
-          "graphic",
-          "hearing",
-          "interview",
-          "legal_case",
-          "legislation",
-          "manuscript",
-          "map",
-          "motion_picture",
-          "musical_score",
-          "pamphlet",
-          "paper-conference",
-          "patent",
-          "performance",
-          "periodical",
-          "personal_communication",
-          "post",
-          "post-weblog",
-          "regulation",
-          "report",
-          "review",
-          "review-book",
-          "software",
-          "song",
-          "speech",
-          "standard",
-          "thesis",
-          "treaty",
-          "webpage"
-        ]
-      },
-      "id": {
-        "$ref": "#/definitions/id-variable"
-      },
-      "categories": {
-        "type": "array",
-        "items": {
-          "type": "string"
-        }
-      },
-      "language": {
-        "type": "string"
-      },
-      "journalAbbreviation": {
-        "type": "string"
-      },
-      "shortTitle": {
-        "type": "string"
-      },
-      "author": {
-        "type": "array",
-        "items": {
-          "$ref": "#/definitions/name-variable"
-        }
-      },
-      "chair": {
-        "type": "array",
-        "items": {
-          "$ref": "#/definitions/name-variable"
-        }
-      },
-      "collection-editor": {
-        "type": "array",
-        "items": {
-          "$ref": "#/definitions/name-variable"
-        }
-      },
-      "compiler": {
-        "type": "array",
-        "items": {
-          "$ref": "#/definitions/name-variable"
-        }
-      },
-      "composer": {
-        "type": "array",
-        "items": {
-          "$ref": "#/definitions/name-variable"
-        }
-      },
-      "container-author": {
-        "type": "array",
-        "items": {
-          "$ref": "#/definitions/name-variable"
-        }
-      },
-      "contributor": {
-        "type": "array",
-        "items": {
-          "$ref": "#/definitions/name-variable"
-        }
-      },
-      "curator": {
-        "type": "array",
-        "items": {
-          "$ref": "#/definitions/name-variable"
-        }
-      },
-      "director": {
-        "type": "array",
-        "items": {
-          "$ref": "#/definitions/name-variable"
-        }
-      },
-      "editor": {
-        "type": "array",
-        "items": {
-          "$ref": "#/definitions/name-variable"
-        }
-      },
-      "editorial-director": {
-        "type": "array",
-        "items": {
-          "$ref": "#/definitions/name-variable"
-        }
-      },
-      "executive-producer": {
-        "type": "array",
-        "items": {
-          "$ref": "#/definitions/name-variable"
-        }
-      },
-      "interviewer": {
-        "type": "array",
-        "items": {
-          "$ref": "#/definitions/name-variable"
-        }
-      },
-      "illustrator": {
-        "type": "array",
-        "items": {
-          "$ref": "#/definitions/name-variable"
-        }
-      },
-      "organizer": {
-        "type": "array",
-        "items": {
-          "$ref": "#/definitions/name-variable"
-        }
-      },
-      "original-author": {
-        "description": "[Deprecated - Use `original` related `author` property instead]",
-        "type": "array",
-        "items": {
-          "$ref": "#/definitions/name-variable"
-        }
-      },
-      "performer": {
-        "type": "array",
-        "items": {
-          "$ref": "#/definitions/name-variable"
-        }
-      },
-      "producer": {
-        "type": "array",
-        "items": {
-          "$ref": "#/definitions/name-variable"
-        }
-      },
-      "recipient": {
-        "type": "array",
-        "items": {
-          "$ref": "#/definitions/name-variable"
-        }
-      },
-      "reviewed-author": {
-        "description": "[Deprecated - Use `reviewed` related `author` property instead]",
-        "type": "array",
-        "items": {
-          "$ref": "#/definitions/name-variable"
-        }
-      },
-      "translator": {
-        "type": "array",
-        "items": {
-          "$ref": "#/definitions/name-variable"
-        }
-      },
-      "accessed": {
-        "$ref": "#/definitions/date-variable"
-      },
-      "available-date": {
-        "$ref": "#/definitions/date-variable"
-      },
-      "container": {
-        "$ref": "#/definitions/date-variable"
-      },
-      "event-date": {
-        "$ref": "#/definitions/date-variable"
-      },
-      "issued": {
-        "$ref": "#/definitions/date-variable"
-      },
-      "original-date": {
-        "$ref": "#/definitions/date-variable"
-      },
-      "submitted": {
-        "$ref": "#/definitions/date-variable"
-      },
-      "abstract": {
-        "type": "string"
-      },
-      "annote": {
-        "type": "string"
-      },
-      "archive": {
-        "type": "string"
-      },
-      "archive_collection": {
-        "type": "string"
-      },
-      "archive_location": {
-        "type": "string"
-      },
-      "archive-place": {
-        "type": "string"
-      },
-      "authority": {
-        "type": "string"
-      },
-      "call-number": {
-        "type": "string"
-      },
-      "chapter-number": {
-        "type": ["string", "number"]
-      },
-      "citation-number": {
-        "type": ["string", "number"]
-      },
-      "citation-label": {
-        "type": "string"
-      },
-      "collection-number": {
-        "type": ["string", "number"]
-      },
-      "collection-title": {
-        "type": "string"
-      },
-      "container-title": {
-        "type": "string"
-      },
-      "container-title-short": {
-        "type": "string"
-      },
-      "dimensions": {
-        "type": "string"
-      },
-      "division": {
-        "type": "string"
-      },
-      "DOI": {
-        "type": "string"
-      },
-      "edition": {
-        "type": ["string", "number"]
-      },
-      "event": {
-        "type": "string"
-      },
-      "event-place": {
-        "type": "string"
-      },
-      "first-reference-note-number": {
-        "type": ["string", "number"]
-      },
-      "genre": {
-        "type": "string"
-      },
-      "ISAN": {
-        "type": "string"
-      },
-      "ISBN": {
-        "type": "string"
-      },
-      "ISCI": {
-        "type": "string"
-      },
-      "ISMN": {
-        "type": "string"
-      },
-      "ISRC": {
-        "type": "string"
-      },
-      "ISSN": {
-        "type": "string"
-      },
-      "ISWC": {
-        "type": "string"
-      },
-      "issue": {
-        "type": ["string", "number"]
-      },
-      "jurisdiction": {
-        "type": "string"
-      },
-      "keyword": {
-        "type": "string"
-      },
-      "locator": {
-        "type": ["string", "number"]
-      },
-      "medium": {
-        "type": "string"
-      },
-      "note": {
-        "type": "string"
-      },
-      "number": {
-        "type": ["string", "number"]
-      },
-      "number-of-pages": {
-        "type": ["string", "number"]
-      },
-      "number-of-volumes": {
-        "type": ["string", "number"]
-      },
-      "original": {
-        "title": "Original Related Item",
-        "$ref": "#/definitions/related-item"
-      },
-      "original-publisher": {
-        "description": "[Deprecated - Use `original` related `publisher` property instead]",
-        "type": "string"
-      },
-      "original-publisher-place": {
-        "description": "[Deprecated - Use `original` related `publisher-place` property instead]",
-        "type": "string"
-      },
-      "original-title": {
-        "description": "[Deprecated - Use `original` related `title` property instead]",
-        "type": "string"
-      },
-      "page": {
-        "type": ["string", "number"]
-      },
-      "page-first": {
-        "type": ["string", "number"]
-      },
-      "part": {
-        "type": ["string", "number"]
-      },
-      "part-title": {
-        "type": "string"
-      },
-      "PMCID": {
-        "type": "string"
-      },
-      "PMID": {
-        "type": "string"
-      },
-      "printing": {
-        "type": ["string", "number"]
-      },
-      "publisher": {
-        "type": "string"
-      },
-      "publisher-place": {
-        "type": "string"
-      },
-      "references": {
-        "type": "string"
-      },
-      "reviewed": {
-        "title": "Reviewed Related Item",
-        "$ref": "#/definitions/related-item"
-      },
-      "reviewed-title": {
-        "description": "[Deprecated - Use `reviewed` related `title` property instead]",
-        "type": "string"
-      },
-      "scale": {
-        "type": "string"
-      },
-      "section": {
-        "type": "string"
-      },
-      "source": {
-        "type": "string"
-      },
-      "status": {
-        "type": "string"
-      },
-      "supplement": {
-        "type": ["string", "number"]
-      },
-      "title": {
-        "type": "string"
-      },
-      "title-short": {
-        "type": "string"
-      },
-      "translated-title": {
-        "type": "string"
-      },
-      "translated-title-short": {
-        "type": "string"
-      },
-      "URL": {
-        "type": "string"
-      },
-      "version": {
-        "type": "string"
-      },
-      "volume": {
-        "type": ["string", "number"]
-      },
-      "year-suffix": {
-        "type": "string"
-      },
-      "custom": {
-        "title": "Custom key-value pairs.",
-        "type": "object",
-        "description": "Used to store additional information that does not have a designated CSL JSON field. The note field can also store additional information, but custom is preferred for storing key-value pairs.",
-        "examples": [
-          {
-            "short_id": "xyz",
-            "other-ids": ["alternative-id"]
-          },
-          {
-            "metadata-double-checked": true
-          }
-        ]
-      }
-    },
-    "required": ["type", "id"],
-    "additionalProperties": false
+    "$ref": "#/definitions/refitem"
   },
   "definitions": {
     "edtf-string": {
@@ -587,14 +143,6 @@
     "id-variable": {
       "type": ["string", "number"]
     },
-    "related-item": {
-      "type": "object",
-      "$ref": "#/definitions/related-item-variable"
-    },
-    "related-item-variable": {
-      "description": "The id for a related item, to be included in the output.",
-      "$ref": "#/definitions/id-variable"
-    },
     "name-variable": {
       "anyOf": [
         {
@@ -630,6 +178,453 @@
           "additionalProperties": false
         }
       ]
+    },
+    "refitem": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "article",
+            "article-journal",
+            "article-magazine",
+            "article-newspaper",
+            "bill",
+            "book",
+            "broadcast",
+            "chapter",
+            "classic",
+            "collection",
+            "dataset",
+            "document",
+            "entry",
+            "entry-dictionary",
+            "entry-encyclopedia",
+            "figure",
+            "graphic",
+            "hearing",
+            "interview",
+            "legal_case",
+            "legislation",
+            "manuscript",
+            "map",
+            "motion_picture",
+            "musical_score",
+            "pamphlet",
+            "paper-conference",
+            "patent",
+            "performance",
+            "periodical",
+            "personal_communication",
+            "post",
+            "post-weblog",
+            "regulation",
+            "report",
+            "review",
+            "review-book",
+            "software",
+            "song",
+            "speech",
+            "standard",
+            "thesis",
+            "treaty",
+            "webpage"
+          ]
+        },
+        "id": {
+          "$ref": "#/definitions/id-variable"
+        },
+        "categories": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "language": {
+          "type": "string"
+        },
+        "journalAbbreviation": {
+          "type": "string"
+        },
+        "shortTitle": {
+          "type": "string"
+        },
+        "author": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/name-variable"
+          }
+        },
+        "chair": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/name-variable"
+          }
+        },
+        "collection-editor": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/name-variable"
+          }
+        },
+        "compiler": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/name-variable"
+          }
+        },
+        "composer": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/name-variable"
+          }
+        },
+        "container-author": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/name-variable"
+          }
+        },
+        "contributor": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/name-variable"
+          }
+        },
+        "curator": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/name-variable"
+          }
+        },
+        "director": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/name-variable"
+          }
+        },
+        "editor": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/name-variable"
+          }
+        },
+        "editorial-director": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/name-variable"
+          }
+        },
+        "executive-producer": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/name-variable"
+          }
+        },
+        "interviewer": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/name-variable"
+          }
+        },
+        "illustrator": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/name-variable"
+          }
+        },
+        "organizer": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/name-variable"
+          }
+        },
+        "original-author": {
+          "description": "[Deprecated - Use `original` related `author` property instead]",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/name-variable"
+          }
+        },
+        "performer": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/name-variable"
+          }
+        },
+        "producer": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/name-variable"
+          }
+        },
+        "recipient": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/name-variable"
+          }
+        },
+        "reviewed-author": {
+          "description": "[Deprecated - Use `reviewed` related `author` property instead]",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/name-variable"
+          }
+        },
+        "translator": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/name-variable"
+          }
+        },
+        "accessed": {
+          "$ref": "#/definitions/date-variable"
+        },
+        "available-date": {
+          "$ref": "#/definitions/date-variable"
+        },
+        "container": {
+          "$ref": "#/definitions/date-variable"
+        },
+        "event-date": {
+          "$ref": "#/definitions/date-variable"
+        },
+        "issued": {
+          "$ref": "#/definitions/date-variable"
+        },
+        "original-date": {
+          "$ref": "#/definitions/date-variable"
+        },
+        "submitted": {
+          "$ref": "#/definitions/date-variable"
+        },
+        "abstract": {
+          "type": "string"
+        },
+        "annote": {
+          "type": "string"
+        },
+        "archive": {
+          "type": "string"
+        },
+        "archive_collection": {
+          "type": "string"
+        },
+        "archive_location": {
+          "type": "string"
+        },
+        "archive-place": {
+          "type": "string"
+        },
+        "authority": {
+          "type": "string"
+        },
+        "call-number": {
+          "type": "string"
+        },
+        "chapter-number": {
+          "type": ["string", "number"]
+        },
+        "citation-number": {
+          "type": ["string", "number"]
+        },
+        "citation-label": {
+          "type": "string"
+        },
+        "collection-number": {
+          "type": ["string", "number"]
+        },
+        "collection-title": {
+          "type": "string"
+        },
+        "container-title": {
+          "type": "string"
+        },
+        "container-title-short": {
+          "type": "string"
+        },
+        "dimensions": {
+          "type": "string"
+        },
+        "division": {
+          "type": "string"
+        },
+        "DOI": {
+          "type": "string"
+        },
+        "edition": {
+          "type": ["string", "number"]
+        },
+        "event": {
+          "type": "string"
+        },
+        "event-place": {
+          "type": "string"
+        },
+        "first-reference-note-number": {
+          "type": ["string", "number"]
+        },
+        "genre": {
+          "type": "string"
+        },
+        "ISAN": {
+          "type": "string"
+        },
+        "ISBN": {
+          "type": "string"
+        },
+        "ISCI": {
+          "type": "string"
+        },
+        "ISMN": {
+          "type": "string"
+        },
+        "ISRC": {
+          "type": "string"
+        },
+        "ISSN": {
+          "type": "string"
+        },
+        "ISWC": {
+          "type": "string"
+        },
+        "issue": {
+          "type": ["string", "number"]
+        },
+        "jurisdiction": {
+          "type": "string"
+        },
+        "keyword": {
+          "type": "string"
+        },
+        "locator": {
+          "type": ["string", "number"]
+        },
+        "medium": {
+          "type": "string"
+        },
+        "note": {
+          "type": "string"
+        },
+        "number": {
+          "type": ["string", "number"]
+        },
+        "number-of-pages": {
+          "type": ["string", "number"]
+        },
+        "number-of-volumes": {
+          "type": ["string", "number"]
+        },
+        "original": {
+          "title": "Original Related Item",
+          "$ref": "#/definitions/refitem"
+        },
+        "original-publisher": {
+          "description": "[Deprecated - Use `original` related `publisher` property instead]",
+          "type": "string"
+        },
+        "original-publisher-place": {
+          "description": "[Deprecated - Use `original` related `publisher-place` property instead]",
+          "type": "string"
+        },
+        "original-title": {
+          "description": "[Deprecated - Use `original` related `title` property instead]",
+          "type": "string"
+        },
+        "page": {
+          "type": ["string", "number"]
+        },
+        "page-first": {
+          "type": ["string", "number"]
+        },
+        "part": {
+          "type": ["string", "number"]
+        },
+        "part-title": {
+          "type": "string"
+        },
+        "PMCID": {
+          "type": "string"
+        },
+        "PMID": {
+          "type": "string"
+        },
+        "printing": {
+          "type": ["string", "number"]
+        },
+        "publisher": {
+          "type": "string"
+        },
+        "publisher-place": {
+          "type": "string"
+        },
+        "references": {
+          "type": "string"
+        },
+        "reviewed": {
+          "title": "Reviewed Related Item",
+          "$ref": "#/definitions/refitem"
+        },
+        "reviewed-title": {
+          "description": "[Deprecated - Use `reviewed` related `title` property instead]",
+          "type": "string"
+        },
+        "scale": {
+          "type": "string"
+        },
+        "section": {
+          "type": "string"
+        },
+        "source": {
+          "type": "string"
+        },
+        "status": {
+          "type": "string"
+        },
+        "supplement": {
+          "type": ["string", "number"]
+        },
+        "title": {
+          "type": "string"
+        },
+        "title-short": {
+          "type": "string"
+        },
+        "translated-title": {
+          "type": "string"
+        },
+        "translated-title-short": {
+          "type": "string"
+        },
+        "URL": {
+          "type": "string"
+        },
+        "version": {
+          "type": "string"
+        },
+        "volume": {
+          "type": ["string", "number"]
+        },
+        "year-suffix": {
+          "type": "string"
+        },
+        "custom": {
+          "title": "Custom key-value pairs.",
+          "type": "object",
+          "description": "Used to store additional information that does not have a designated CSL JSON field. The note field can also store additional information, but custom is preferred for storing key-value pairs.",
+          "examples": [
+            {
+              "short_id": "xyz",
+              "other-ids": ["alternative-id"]
+            },
+            {
+              "metadata-double-checked": true
+            }
+          ]
+        }
+      },
+      "required": ["type"],
+      "additionalProperties": false
     }
   }
 }

--- a/schemas/input/csl-data.json
+++ b/schemas/input/csl-data.json
@@ -164,6 +164,7 @@
         }
       },
       "original-author": {
+        "description": "[Deprecated - Use `original` related `author` property instead]",
         "type": "array",
         "items": {
           "$ref": "#/definitions/name-variable"
@@ -188,6 +189,7 @@
         }
       },
       "reviewed-author": {
+        "description": "[Deprecated - Use `reviewed` related `author` property instead]",
         "type": "array",
         "items": {
           "$ref": "#/definitions/name-variable"
@@ -338,12 +340,15 @@
         "type": ["string", "number"]
       },
       "original-publisher": {
+        "description": "[Deprecated - Use `original` related `publisher` property instead]",
         "type": "string"
       },
       "original-publisher-place": {
+        "description": "[Deprecated - Use `original` related `publisher-place` property instead]",
         "type": "string"
       },
       "original-title": {
+        "description": "[Deprecated - Use `original` related `title` property instead]",
         "type": "string"
       },
       "page": {
@@ -377,6 +382,7 @@
         "type": "string"
       },
       "reviewed-title": {
+        "description": "[Deprecated - Use `reviewed` related `title` property instead]",
         "type": "string"
       },
       "scale": {

--- a/schemas/input/csl-data.json
+++ b/schemas/input/csl-data.json
@@ -339,6 +339,10 @@
       "number-of-volumes": {
         "type": ["string", "number"]
       },
+      "original": {
+        "title": "Original Related Item",
+        "$ref": "#/definitions/related-item"
+      },
       "original-publisher": {
         "description": "[Deprecated - Use `original` related `publisher` property instead]",
         "type": "string"
@@ -380,6 +384,10 @@
       },
       "references": {
         "type": "string"
+      },
+      "reviewed": {
+        "title": "Reviewed Related Item",
+        "$ref": "#/definitions/related-item"
       },
       "reviewed-title": {
         "description": "[Deprecated - Use `reviewed` related `title` property instead]",
@@ -423,10 +431,6 @@
       },
       "year-suffix": {
         "type": "string"
-      },
-      "related": {
-        "type": "array",
-        "items": [{ "$ref": "#/definitions/related-item" }]
       },
       "custom": {
         "title": "Custom key-value pairs.",
@@ -585,18 +589,11 @@
     },
     "related-item": {
       "type": "object",
-      "properties": {
-        "original": {
-          "$ref": "#/definitions/related-item-variable"
-        },
-        "reviewed": {
-          "$ref": "#/definitions/related-item-variable"
-        }
-      }
+      "$ref": "#/definitions/related-item-variable"
     },
     "related-item-variable": {
       "description": "The id for a related item, to be included in the output.",
-      "oneOf": [{ "$ref": "#/definitions/id-variable" }]
+      "$ref": "#/definitions/id-variable"
     },
     "name-variable": {
       "anyOf": [

--- a/schemas/input/csl-data.json
+++ b/schemas/input/csl-data.json
@@ -393,6 +393,7 @@
           "$ref": "#/definitions/date-variable"
         },
         "original-date": {
+          "description": "[Deprecated - Use `original` related date property instead]",
           "$ref": "#/definitions/date-variable"
         },
         "submitted": {

--- a/schemas/input/csl-data.json
+++ b/schemas/input/csl-data.json
@@ -56,7 +56,7 @@
         ]
       },
       "id": {
-        "type": ["string", "number"]
+        "$ref": "#/definitions/id-variable"
       },
       "categories": {
         "type": "array",
@@ -418,6 +418,10 @@
       "year-suffix": {
         "type": "string"
       },
+      "related": {
+        "type": "array",
+        "items": [{ "$ref": "#/definitions/related-item" }]
+      },
       "custom": {
         "title": "Custom key-value pairs.",
         "type": "object",
@@ -517,13 +521,27 @@
           "id": "range-1",
           "type": "book",
           "title": "The Title",
-          "issued": [{ "year": 2000 }, { "year": 2001 }]
+          "issued": [
+            {
+              "year": 2000
+            },
+            {
+              "year": 2001
+            }
+          ]
         },
         {
           "id": "range-2",
           "type": "book",
           "title": "The Title",
-          "issued": [{ "year": 2000 }, { "undefined": true }]
+          "issued": [
+            {
+              "year": 2000
+            },
+            {
+              "undefined": true
+            }
+          ]
         }
       ],
       "items": {
@@ -555,6 +573,24 @@
           "$ref": "#/definitions/date-structured"
         }
       ]
+    },
+    "id-variable": {
+      "type": ["string", "number"]
+    },
+    "related-item": {
+      "type": "object",
+      "properties": {
+        "original": {
+          "$ref": "#/definitions/related-item-variable"
+        },
+        "reviewed": {
+          "$ref": "#/definitions/related-item-variable"
+        }
+      }
+    },
+    "related-item-variable": {
+      "description": "The id for a related item, to be included in the output.",
+      "oneOf": [{ "$ref": "#/definitions/id-variable" }]
     },
     "name-variable": {
       "anyOf": [


### PR DESCRIPTION
The CSL 1.0 style schema adopted a flat key-value data model for standard variables like titles and identifiers.

The 1.0 JSON schema was designed to provide a machine-readable way to feed CSL processors with a model that matched the style model.

Since then, CSL, and the use of CSL JSON, has exploded, as have the number of feature requests. 

Recent development work put us in a situation where we could have ended up with well over 100 variables to support new features (see #167), which does not seem practical.

This PR aims to make the input schema simpler and more flexible, without needing to add new variables whenever there's a feature request.