### PR TITLE
add reviewed-genre variable

### DIFF
--- a/schemas/input/csl-data.json
+++ b/schemas/input/csl-data.json
@@ -376,6 +376,9 @@
       "references": {
         "type": "string"
       },
+      "reviewed-genre": {
+        "type": "string"
+      },
       "reviewed-title": {
         "type": "string"
       },

--- a/schemas/styles/csl-variables.rnc
+++ b/schemas/styles/csl-variables.rnc
@@ -105,6 +105,7 @@ div {
     | "publisher"
     | "publisher-place"
     | "references"
+    | "reviewed-genre"
     | "reviewed-title"
     | "scale"
     | "section"


### PR DESCRIPTION
## Description

Regarding `reviewed-genre`, it's the major variable that is missing from being able to describe what type of review a `review` item is. Most reviews could be reasonably be handled with this variable and the existing `reviewed-` variables. Better support for non-book `original-` items requires too many individual variables.

_Originally posted by @bwiernik in https://github.com/citation-style-language/schema/issues/167#issuecomment-647803302_
Please also include relevant motivation and context, on a separate line.

## Type of change

Please delete options that are not relevant.

- [X] Variable addition (adds a new variable or type string)
- [X] This change requires a documentation update

## Checklist

- [X] I have installed the repo [pre-commit hook](https://github.com/citation-style-language/schema/blob/master/CONTRIBUTING.md#pre-commit-hooks); if not, and I have modified any of the schema files, I have run trang and/or prettier on the files, per [CONTRIBUTING](https://github.com/citation-style-language/schema/blob/master/CONTRIBUTING.md)
- [X] I have performed a self-review of my own code
- [X] I have included suggested corresponding changes to the documentation (if relevant)
