### PR TITLE
Add sub/main form values to cs:text

### DIFF
--- a/schemas/styles/csl-variables.rnc
+++ b/schemas/styles/csl-variables.rnc
@@ -3,14 +3,14 @@ namespace a = "http://relaxng.org/ns/compatibility/annotations/1.0"
 
 ## Variables
 div {
-  
+
   ## All variables
   variables = variables.dates | variables.names | variables.standard
-  
+
   ## Standard variables
   variables.standard =
     variables.numbers | variables.strings | variables.titles
-  
+
   ## Date variables
   variables.dates =
     "accessed"
@@ -20,7 +20,7 @@ div {
     | "issued"
     | "original-date"
     | "submitted"
-  
+
   ## Name variables
   variables.names =
     "author"
@@ -44,7 +44,7 @@ div {
     | "recipient"
     | "reviewed-author"
     | "translator"
-  
+
   ## Number variables
   variables.numbers =
     "chapter-number"
@@ -63,22 +63,16 @@ div {
     | "printing"
     | "supplement"
     | "volume"
-  
+
   ## Title variables
   variables.titles =
     "collection-title"
-    | "collection-title-short"
     | "container-title"
-    | "container-title-short"
     | "original-title"
-    | "original-title-short"
     | "reviewed-title"
-    | "reviewed-title-short"
     | "volume-title"
-    | "volume-title-short"
     | "title"
-    | "title-short"
-  
+
   ## String variables
   variables.strings =
     "abstract"
@@ -122,10 +116,7 @@ div {
     | "section"
     | "source"
     | "status"
-    | "title"
-    | "title-short"
     | "translated-title"
-    | "translated-title-short"
     | "URL"
     | "version"
     | "year-suffix"

--- a/schemas/styles/csl-variables.rnc
+++ b/schemas/styles/csl-variables.rnc
@@ -67,28 +67,16 @@ div {
   ## Title variables
   variables.titles =
     "collection-title"
-    | "collection-title-main"
-    | "collection-title-sub"
     | "collection-title-short"
     | "container-title"
-    | "container-title-main"
-    | "container-title-sub"
     | "container-title-short"
     | "original-title"
-    | "original-title-main"
-    | "original-title-sub"
     | "original-title-short"
     | "reviewed-title"
-    | "reviewed-title-main"
-    | "reviewed-title-sub"
     | "reviewed-title-short"
     | "volume-title"
-    | "volume-title-main"
-    | "volume-title-sub"
     | "volume-title-short"
     | "title"
-    | "title-main"
-    | "title-sub"
     | "title-short"
   
   ## String variables

--- a/schemas/styles/csl-variables.rnc
+++ b/schemas/styles/csl-variables.rnc
@@ -69,9 +69,11 @@ div {
     "collection-title"
     | "container-title"
     | "original-title"
+    | "part-title"
     | "reviewed-title"
-    | "volume-title"
     | "title"
+    | "translated-title"
+    | "volume-title"
 
   ## String variables
   variables.strings =
@@ -105,8 +107,6 @@ div {
     | "note"
     | "original-publisher"
     | "original-publisher-place"
-    | "original-title"
-    | "part-title"
     | "PMCID"
     | "PMID"
     | "publisher"
@@ -116,7 +116,6 @@ div {
     | "section"
     | "source"
     | "status"
-    | "translated-title"
     | "URL"
     | "version"
     | "year-suffix"

--- a/schemas/styles/csl.rnc
+++ b/schemas/styles/csl.rnc
@@ -125,7 +125,7 @@ div {
   info.id =
     
     ## Specify the unique and stable identifier for the style. A URI
-    ## is valid, but new styles should use a UUID to ensure stability 
+    ## is valid, but new styles should use a UUID to ensure stability
     ## and uniqueness.
     element cs:id { xsd:anyURI }
   info.issn =
@@ -321,6 +321,11 @@ div {
       attribute name { xsd:NMTOKEN },
       rendering-element+
     }
+}
+# ==============================================================================
+
+## Rendering Elements
+div {
   rendering-element =
     rendering-element.names
     | rendering-element.date
@@ -641,10 +646,11 @@ div {
     | 
       ## Specify verbatim text.
       attribute value { text }
-    | (
-       ## Select a variable.
-       attribute variable { variables.standard },
-       [ a:defaultValue = "long" ] attribute form { "short" | "long" }?)
+    | ((attribute variable { variables.numbers | variables.strings },
+        [ a:defaultValue = "long" ] attribute form { "short" | "long" })
+       | (attribute variable { variables.titles },
+          [ a:defaultValue = "long" ]
+          attribute form { "short" | "long" | "sub" | "main" })?)
 }
 # ==============================================================================
 
@@ -909,7 +915,7 @@ div {
     [ a:defaultValue = "simple" ]
     attribute title-split {
       
-      ## Matches "."", ":", "::", "!", "?" 
+      ## Matches "."", ":", "::", "!", "?"
       "simple"
       | 
         ## Matches the values for "simple" plus ";"
@@ -918,7 +924,7 @@ div {
         ## Matches the values for "simple" plus "—" and ";"
         "full"
       | 
-        ## Matches the values for "simple" plus ";"" 
+        ## Matches the values for "simple" plus ";""
         ## and "[;,] or[,:]" (see CMoS 14.91), e.g.  "Moby-Dick; or, The Whale"
         "chicago"
     }?,


### PR DESCRIPTION
## Description

This moves specification of split title components from dedicated variables to new "sub" and "main" `@form` values.

Removes the -short title variable variants as well.

## Type of change

- [X] New feature (non-breaking change which adds functionality)
- [X] This change requires a documentation update

