### PR TITLE
Add editor-translator as testable variable

### DIFF
--- a/schemas/styles/csl-variables.rnc
+++ b/schemas/styles/csl-variables.rnc
@@ -33,6 +33,7 @@ div {
     | "curator"
     | "director"
     | "editor"
+    | "editor-translator"
     | "editorial-director"
     | "executive-producer"
     | "illustrator"


### PR DESCRIPTION
## Description

Add editor-translator to the RNC schema to make it a testable variable. This makes it possible to modify the formatting of editor and translator depending on if they are the same person or not. The variable itself is still populated by the processor collapsing editor and translator.

This would require a minor update to processor code. They already have the editortranslator collapsing code; but they would likely need a small modification to call it during and if test. Given that, probably v1.1, rather than 1.0.2?

Fixes part of # citation-style-language/csl-evolution#7

## Type of change

Please delete options that are not relevant.

- [X] Variable addition (adds a new variable or type string)
- [X] New feature (non-breaking change which adds functionality)
- [X] This change requires a documentation update
