### PR TITLE
Move "section", "version" strings to numbers

### DIFF
--- a/schemas/styles/csl-variables.rnc
+++ b/schemas/styles/csl-variables.rnc
@@ -60,6 +60,7 @@ div {
     | "page-first"
     | "part"
     | "printing"
+    | "section"
     | "supplement"
     | "volume"
   
@@ -109,7 +110,6 @@ div {
     | "reviewed-genre"
     | "reviewed-title"
     | "scale"
-    | "section"
     | "source"
     | "status"
     | "title"

--- a/schemas/styles/csl-variables.rnc
+++ b/schemas/styles/csl-variables.rnc
@@ -62,6 +62,7 @@ div {
     | "printing"
     | "section"
     | "supplement"
+    | "version"
     | "volume"
   
   ## String variables
@@ -117,7 +118,6 @@ div {
     | "translated-title"
     | "translated-title-short"
     | "URL"
-    | "version"
     | "volume-title"
     | "year-suffix"
 }


### PR DESCRIPTION
## Description

What it says: Move `section` to numbers. Makes `label="section"` available.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] This change requires a documentation update
