### PR TITLE
Remove `container`

### DIFF
--- a/schemas/input/csl-data.json
+++ b/schemas/input/csl-data.json
@@ -208,9 +208,6 @@
       "available-date": {
         "$ref": "#/definitions/date-variable"
       },
-      "container": {
-        "$ref": "#/definitions/date-variable"
-      },
       "event-date": {
         "$ref": "#/definitions/date-variable"
       },

--- a/schemas/styles/csl-variables.rnc
+++ b/schemas/styles/csl-variables.rnc
@@ -14,7 +14,6 @@ div {
   variables.dates =
     "accessed"
     | "available-date"
-    | "container"
     | "event-date"
     | "issued"
     | "original-date"


### PR DESCRIPTION
## Description

Remove the date variable `container`, which doesn't make much of any sense.

Closes # https://github.com/citation-style-language/documentation/pull/41

## Type of change

Please delete options that are not relevant.

- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - (Need to remove `container` from a small number of repo styles.)
- [X] This change requires a documentation update
