### PR TITLE
CSL JSON Data schema: add custom field

### DIFF
--- a/schemas/input/csl-data.json
+++ b/schemas/input/csl-data.json
@@ -417,6 +417,15 @@
       },
       "year-suffix": {
         "type": "string"
+      },
+      "custom": {
+        "title": "Custom key-value pairs.",
+        "type": "object",
+        "description": "Used to store additional information that does not have a designated CSL JSON field. The note field can also store additional information, but custom is preferred for storing key-value pairs.",
+        "examples" : [
+          {"short_id": "xyz", "other-ids": ["alternative-id"]},
+          {"metadata-double-checked": true}
+        ]
       }
     },
     "required": ["type", "id"],


### PR DESCRIPTION
closes https://github.com/citation-style-language/schema/issues/277

let me know if any other files need to be changed. I added `title` and `description` as per #190. Hopefully we can eventually auto-generate CSL JSON docs from this... but are there docs that need to be updated manually now?