### PR TITLE
(input): Add EDTF as an option for date representation

### DIFF
--- a/schemas/input/csl-data.json
+++ b/schemas/input/csl-data.json
@@ -477,7 +477,7 @@
       "title": "EDTF datatype pattern",
       "description": "CSL input supports EDTF, validated against this regular expression.",
       "type": "string",
-      "pattern": "[0-9,\-,%,~,X,?,..,\/]"
+      "pattern": "[0-9,-,%,~,X,?,..,\/]"
     },
     "date-variable": {
       "title": "Date content model.",

--- a/schemas/input/csl-data.json
+++ b/schemas/input/csl-data.json
@@ -476,7 +476,8 @@
     "edtf-datatype": {
       "title": "EDTF datatype pattern",
       "description": "CSL input supports EDTF, validated against this regular expression.",
-      "type": "string"
+      "type": "string",
+      "pattern": "[0-9,\-,%,~,X,?,..,\/]"
     },
     "date-variable": {
       "title": "Date content model.",

--- a/schemas/input/csl-data.json
+++ b/schemas/input/csl-data.json
@@ -477,7 +477,7 @@
       "title": "EDTF datatype pattern",
       "description": "CSL input supports EDTF, validated against this regular expression.",
       "type": "string",
-      "pattern": "[0-9,-,%,~,X,?,..,\/]"
+      "pattern": "^[0-9-%~X?.\/]{4,}$"
     },
     "date-variable": {
       "title": "Date content model.",

--- a/schemas/input/csl-data.json
+++ b/schemas/input/csl-data.json
@@ -481,7 +481,7 @@
     },
     "date-variable": {
       "title": "Date content model.",
-      "description": "The CSL input model supports two different date representations: a preferred EDTF string, and a more structured alternative.",
+      "description": "The CSL input model supports two different date representations: an EDTF string (preferred), and a more structured alternative.",
       "anyOf": [
         {
           "$ref": "#/definitions/edtf-datatype"

--- a/schemas/input/csl-data.json
+++ b/schemas/input/csl-data.json
@@ -422,9 +422,14 @@
         "title": "Custom key-value pairs.",
         "type": "object",
         "description": "Used to store additional information that does not have a designated CSL JSON field. The note field can also store additional information, but custom is preferred for storing key-value pairs.",
-        "examples" : [
-          {"short_id": "xyz", "other-ids": ["alternative-id"]},
-          {"metadata-double-checked": true}
+        "examples": [
+          {
+            "short_id": "xyz",
+            "other-ids": ["alternative-id"]
+          },
+          {
+            "metadata-double-checked": true
+          }
         ]
       }
     },
@@ -468,8 +473,18 @@
         }
       ]
     },
+    "edtf-datatype": {
+      "title": "EDTF datatype pattern",
+      "description": "CSL input supports EDTF, validated against this regular expression.",
+      "type": "string"
+    },
     "date-variable": {
+      "title": "Date content model.",
+      "description": "The CSL input model supports two different date representations: an EDTF string, and a more structured equivalent.",
       "anyOf": [
+        {
+          "$ref": "#/definitions/edtf-datatype"
+        },
         {
           "properties": {
             "date-parts": {
@@ -496,6 +511,9 @@
             },
             "raw": {
               "type": "string"
+            },
+            "edtf": {
+              "$ref": "#/definitions/edtf-datatype"
             }
           },
           "additionalProperties": false

--- a/schemas/input/csl-data.json
+++ b/schemas/input/csl-data.json
@@ -481,7 +481,7 @@
     },
     "date-variable": {
       "title": "Date content model.",
-      "description": "The CSL input model supports two different date representations: an EDTF string, and a more structured equivalent.",
+      "description": "The CSL input model supports two different date representations: a preferred EDTF string, and a more structured alternative.",
       "anyOf": [
         {
           "$ref": "#/definitions/edtf-datatype"


### PR DESCRIPTION
## Description

As part of #278, and to harmonize the JSON and YAML representations around a much more concise and expressive date format, this adds an option to use [EDTF](https://www.loc.gov/standards/datetime/).

While [EDTF](https://www.loc.gov/standards/datetime/) was originally an initiative of the US Library of Congress, it seems that in 2019, ISO adopted it as part of [8601-2](https://www.iso.org/obp/ui/#iso:std:iso:8601:-2:ed-1:v1:en).

Example of a date-range with a circa qualifier in the new alternative (using the YAML syntax):

``` yaml
issued: 2004-02-01/2005-02-08?
```
-----

## TODO

1. settle on the precise compliance levels and features we support (for documentation); see below
2. modify regex pattern for validation that reflects 1, or that tightens the validation beyond current
3. long-term status of `date-parts`; do we say deprecated now and remove later, for example, or recommend EDTF?

## Compliance Details

We need to say "Level 0 is supported, and in addition the following features of levels 1 and 2 are supported (list features)."

Note: biblatex formally supports levels 0 and 1.

### Level 0

- Date (`2010-03-10`)
- Time Interval (`2010-03-10/2010-03-11`)

Note: level 0 includes date-times, which I don't think we need.

### Level 1

- Seasons (`2010-21`)
- Negative calendar year (`-0500`)

I'm confident in the above; the rest below are uncertainties; I think I'd prefer to not support, on input at least.

#### Uncertain vs Approximate Dates

- Qualification of Date (`2010-03-04?` means "uncertain"; `~` indicates "approximate" and `%` both)

I remember this discussion during EDTF development, but never understood the practical distinction.

In our case, do we support one or the other, or both?

How?

 _I vote for only one_, which we treat as equivalent to our "circa." But no pun intended, I'm not 100% sure.

#### Other Issues

I'm not sure we need this:

- Unspecified digit(s) from the right (`2010-03-XX`)

We need these "Extended Interval " features on styles, but on input?

- Open end time interval (`1900/..`)
- Open start time interval (`../1900`)
- Time interval with unknown end  (`1900/`)
- Time interval with unknown start (`/1900`)

### Level 2

Do we need "all member" sets? (`{2010-03-04,2010-03-05}`)

### Extension

- season ranges (`2020-21/2020-22`).

----

## EDTF libraries

- https://github.com/inukshuk/edtf.js
- https://github.com/ixc/python-edtf
