### PR TITLE
Add act and scene locators

### DIFF
--- a/schemas/styles/csl-terms.rnc
+++ b/schemas/styles/csl-terms.rnc
@@ -109,7 +109,8 @@ div {
   ## Locator terms that can be tested with the "locator" conditional
   ## ("sub verbo" can be tested with "sub-verbo")
   terms.locator.testable =
-    "appendix"
+    "act"
+    | "appendix"
     | "article"
     | "book"
     | "canon"
@@ -126,6 +127,7 @@ div {
     | "paragraph"
     | "part"
     | "rule"
+    | "scene"
     | "section"
     | "supplement"
     | "table"


### PR DESCRIPTION
## Description

This adds two additional locators: `act` and `scene`.

This were still missing.

Clsoes https://github.com/citation-style-language/schema/issues/288

## Type of change

Please delete options that are not relevant.

- [X] Variable addition (adds a new variable or type string)
- [X] This change requires a documentation update

## Checklist

- [X] I have installed the repo [pre-commit hook](https://github.com/citation-style-language/schema/blob/master/CONTRIBUTING.md#pre-commit-hooks); if not, and I have modified any of the schema files, I have run trang and/or prettier on the files, per [CONTRIBUTING](https://github.com/citation-style-language/schema/blob/master/CONTRIBUTING.md)
- [X] I have performed a self-review of my own code
- [] I have included suggested corresponding changes to the documentation (if relevant)
