### PR TITLE
add locator term sub-verbo, remove legacy workaround

### DIFF
--- a/schemas/styles/csl-choose.rnc
+++ b/schemas/styles/csl-choose.rnc
@@ -40,7 +40,7 @@ div {
     | 
       ## Tests whether the locator matches the given locator types.
       attribute locator {
-        list { (terms.locator.testable | "sub-verbo")+ }
+        list { (terms.locator)+ }
       }
     | 
       ## Tests whether the cite position matches the given positions.

--- a/schemas/styles/csl-terms.rnc
+++ b/schemas/styles/csl-terms.rnc
@@ -100,15 +100,6 @@ div {
   
   ## Locators
   terms.locator =
-    terms.locator.testable
-    | 
-      ## "sub verbo" is recognized as "sub" & "verbo" in attribute lists; term
-      ## should be renamed to "sub-verbo"
-      "sub verbo"
-  
-  ## Locator terms that can be tested with the "locator" conditional
-  ## ("sub verbo" can be tested with "sub-verbo")
-  terms.locator.testable =
     "act"
     | "appendix"
     | "article"
@@ -129,6 +120,7 @@ div {
     | "rule"
     | "scene"
     | "section"
+    | "sub-verbo"
     | "supplement"
     | "table"
     | "timestamp"


### PR DESCRIPTION
## Description

This changes `sub verbo` to `sub-verbo` so this will be testable as is.

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] This change requires a documentation update

## Checklist

- [X] I have installed the repo [pre-commit hook](https://github.com/citation-style-language/schema/blob/master/CONTRIBUTING.md#pre-commit-hooks); if not, and I have modified any of the schema files, I have run trang and/or prettier on the files, per [CONTRIBUTING](https://github.com/citation-style-language/schema/blob/master/CONTRIBUTING.md)
- [X] I have performed a self-review of my own code
