### PR TITLE
Add henceforth term

### DIFF
--- a/schemas/styles/csl-terms.rnc
+++ b/schemas/styles/csl-terms.rnc
@@ -27,6 +27,7 @@ div {
     | "et-al"
     | "forthcoming"
     | "from"
+    | "henceforth"
     | "ibid"
     | "in"
     | "in press"


### PR DESCRIPTION
Used for styles that switch to an abbreviated `citation-label` format for subsequent citations.

Long and short forms might be localized as "henceforth cited as" and "henceforth" respectively.

Closes https://github.com/citation-style-language/csl-evolution/issues/37

## Type of change

- [X] Variable addition (adds a new variable or type string)
- [ ] This change requires a documentation update