### PR TITLE
Add new conditions

### DIFF
--- a/schemas/styles/csl-choose.rnc
+++ b/schemas/styles/csl-choose.rnc
@@ -11,7 +11,7 @@ div {
   
   ## When specifying conditions, we allow either the attribute syntax or the element-based one.
   choose.condition =
-    (condition.atts+, match?)
+    (condition.atts, match?)
     | element cs:conditions { match, condition.elem+ }
   choose.if = element cs:if { choose.condition, rendering-element* }
   choose.else-if =
@@ -21,7 +21,8 @@ div {
   ## This element allows for more complex conditional logic; for 
   ## example, if you need to specify mixed "match" rules.
   condition.elem = element cs:condition { match?, condition.atts }
-  condition.atts =
+  condition.atts = ((condition.atts.simple+, condition.atts.complex) | condition.atts.simple+ | condition.atts.complex)
+  condition.atts.simple =
     
     ## If used, the element content is only rendered if it disambiguates two
     ## otherwise identical citations. This attempt at disambiguation is only

--- a/schemas/styles/csl-choose.rnc
+++ b/schemas/styles/csl-choose.rnc
@@ -12,7 +12,7 @@ div {
   ## When specifying conditions, we allow either the attribute syntax or the element-based one.
   choose.condition =
     (condition.atts, match?)
-    | element cs:conditions { match, condition.elem+ }
+    | element cs:conditions { match?, condition.elem+ }
   choose.if = element cs:if { choose.condition, rendering-element* }
   choose.else-if =
     element cs:else-if { choose.condition, rendering-element* }

--- a/schemas/styles/csl-choose.rnc
+++ b/schemas/styles/csl-choose.rnc
@@ -64,6 +64,17 @@ div {
       attribute variable {
         list { variables+ }
       }
+      |
+      tests-dates
+  
+  # Tests for date variables that require two attributes:
+  tests-dates =
+    attribute tested { 
+      list { variables.dates+ }
+     },
+    attribute date-precision { text },
+    attribute date-range { text }
+
   match =
     
     ## Set the testing logic.

--- a/schemas/styles/csl-choose.rnc
+++ b/schemas/styles/csl-choose.rnc
@@ -64,13 +64,13 @@ div {
       attribute variable {
         list { variables+ }
       }
-      |
-      condition.atts.complex.dates
-      |
-      condition.atts.complex.general
-
   
-  # Tests that require two attributes 
+  # Tests that require two attributes
+  condition.atts.complex.dates = 
+    condition.atts.complex.dates
+    |
+    condition.atts.complex.general
+
   # Dates
   condition.atts.complex.dates =
     ## specifies the variable to be tested

--- a/schemas/styles/csl-choose.rnc
+++ b/schemas/styles/csl-choose.rnc
@@ -81,8 +81,11 @@ div {
      (date-precision | date-range)+
     
   ## Tests the precision of a date variable
-  date-precision = attribute date-precision { 
-    list { ("year" | "month" | "day") }
+  date-precision = attribute date-precision {
+    ## specifies the highlest level of precision of a date variable
+    ## e.g., date-precision="month" means date-parts "year" and "month"
+    ## are present, but "day" is missing.
+    "year" | "month" | "day"
    }
   
   ## Tests whether a date variable is within a given range

--- a/schemas/styles/csl-choose.rnc
+++ b/schemas/styles/csl-choose.rnc
@@ -11,7 +11,7 @@ div {
   
   ## When specifying conditions, we allow either the attribute syntax or the element-based one.
   choose.condition =
-    (condition.atts, match?)
+    (condition.atts+, match?)
     | element cs:conditions { match, condition.elem+ }
   choose.if = element cs:if { choose.condition, rendering-element* }
   choose.else-if =
@@ -66,7 +66,7 @@ div {
       }
   
   # Tests that require two attributes
-  condition.atts.complex.dates = 
+  condition.atts.complex = 
     condition.atts.complex.dates
     |
     condition.atts.complex.general

--- a/schemas/styles/csl-choose.rnc
+++ b/schemas/styles/csl-choose.rnc
@@ -21,7 +21,7 @@ div {
   ## This element allows for more complex conditional logic; for 
   ## example, if you need to specify mixed "match" rules.
   condition.elem = element cs:condition { match?, condition.atts }
-  condition.atts = ((condition.atts.simple+, condition.atts.complex) | condition.atts.simple+ | condition.atts.complex)
+  condition.atts = ((condition.atts.simple+, condition.atts.complex?) | condition.atts.complex)
   condition.atts.simple =
     
     ## If used, the element content is only rendered if it disambiguates two

--- a/schemas/styles/csl-choose.rnc
+++ b/schemas/styles/csl-choose.rnc
@@ -70,23 +70,26 @@ div {
       condition.atts.complex.general
 
   
-  # Tests that require two attributes
+  # Tests that require two attributes 
   # Dates
   condition.atts.complex.dates =
     ## specifies the variable to be tested
     attribute tested { 
       list { variables.dates+ }
      },
-    ## Tests the precision of a date variable
-    attribute date-precision { text },
-    ## Tests whether a date variable is within a given range
-    attribute date-range { text }
+     (date-precision | date-range)+
+    
+  ## Tests the precision of a date variable
+  date-precision = attribute date-precision { text }
+  
+  ## Tests whether a date variable is within a given range
+  date-range = attribute date-range { text }
   
   # General
   condition.atts.complex.general =
     ## specifies the variable to be tested
     attribute tested { 
-      list {variables+ }
+      list { variables+ }
      },
     ## Tests whether the tested variable matches another variable
     attribute matches { 

--- a/schemas/styles/csl-choose.rnc
+++ b/schemas/styles/csl-choose.rnc
@@ -65,15 +65,33 @@ div {
         list { variables+ }
       }
       |
-      tests-dates
+      condition.atts.complex.dates
+      |
+      condition.atts.complex.general
+
   
-  # Tests for date variables that require two attributes:
-  tests-dates =
+  # Tests that require two attributes
+  # Dates
+  condition.atts.complex.dates =
+    ## specifies the variable to be tested
     attribute tested { 
       list { variables.dates+ }
      },
+    ## Tests the precision of a date variable
     attribute date-precision { text },
+    ## Tests whether a date variable is within a given range
     attribute date-range { text }
+  
+  # General
+  condition.atts.complex.general =
+    ## specifies the variable to be tested
+    attribute tested { 
+      list {variables+ }
+     },
+    ## Tests whether the tested variable matches another variable
+    attribute matches { 
+      list {variables+ }
+     }
 
   match =
     

--- a/schemas/styles/csl-choose.rnc
+++ b/schemas/styles/csl-choose.rnc
@@ -80,7 +80,9 @@ div {
      (date-precision | date-range)+
     
   ## Tests the precision of a date variable
-  date-precision = attribute date-precision { text }
+  date-precision = attribute date-precision { 
+    list { ("year" | "month" | "day") }
+   }
   
   ## Tests whether a date variable is within a given range
   date-range = attribute date-range { text }


### PR DESCRIPTION
## Description

WIP
This will add new test condîtions that require two attributes:

- `@tested`: specifies the variables to be tested
- `@matches`: specifies the variable to be tested against
- `@date-range`: tests if a variable is in a given date range
- `@date-precision`: tests whether certain date parts are present.

Fixes #251 #254  #285 

## Questions

The patterns lead to duplicate suggestions when using autocompletion. Anyone knows what to do here?


## Todo
- [X] Currently, the date test requires `date-precision` **and** `date-range`. How can one of them be made optional?
- [X] How can we combine the other tests with the new complex tests? Currently they can't be used together.

## Type of change

- [X] New feature (non-breaking change which adds functionality)
- [X] This change requires a documentation update

## Checklist

- [X] I have installed the repo [pre-commit hook](https://github.com/citation-style-language/schema/blob/master/CONTRIBUTING.md#pre-commit-hooks); if not, and I have modified any of the schema files, I have run trang and/or prettier on the files, per [CONTRIBUTING](https://github.com/citation-style-language/schema/blob/master/CONTRIBUTING.md)
- [X] I have performed a self-review of my own code
- [] I have included suggested corresponding changes to the documentation (if relevant)
