### PR TITLE
adds locale option initial-family-name-delimiter

### DIFF
--- a/schemas/styles/csl.rnc
+++ b/schemas/styles/csl.rnc
@@ -231,6 +231,11 @@ div {
   locale.style-options =
     element cs:style-options {
       
+      ## Specify the space character to be used between initialized first names and family names, 
+      ## e.g. a non-breaking space.
+      [ a:defaultValue = " " ]
+      attribute initial-family-name-delimiter { text }?,
+      
       ## Limit the "ordinal" form to the first day of the month.
       [ a:defaultValue = "false" ]
       attribute limit-day-ordinals-to-day-1 { xsd:boolean }?,


### PR DESCRIPTION
## Description

per https://github.com/citation-style-language/schema/issues/236#issue-635743993:
> Specifically, French typography typically requires a non breaking space here, whereas US typography very much doesn't.
> I.e. `A.&nbsp;Smith` vs. `A. Smith`
> The former is currently impossible in Zotero.
> This should likely be a locale spec

This adds a new locale option `initial-family-name-delimiter`.

Closes #236 

## Type of change

Please delete options that are not relevant.

- [X] New feature (non-breaking change which adds functionality)
- [X] This change requires a documentation update

## Checklist

- [X] I have installed the repo [pre-commit hook](https://github.com/citation-style-language/schema/blob/master/CONTRIBUTING.md#pre-commit-hooks); if not, and I have modified any of the schema files, I have run trang and/or prettier on the files, per [CONTRIBUTING](https://github.com/citation-style-language/schema/blob/master/CONTRIBUTING.md)
- [X] I have performed a self-review of my own code
- [] I have included suggested corresponding changes to the documentation (if relevant)
