### PR TITLE
input: Align date-parts and edtf string models

### DIFF
--- a/schemas/input/csl-data.json
+++ b/schemas/input/csl-data.json
@@ -445,7 +445,18 @@
     },
     "date-object": {
       "title": "Date Object",
-      "description": "An EDTF date represented as an object.",
+      "description": "An EDTF date represented as an object. Seasons can be represented using the 21-24 month values of EDTF, decades and centuries using the X notation, and the qualifiers with the included boolean properties",
+      "examples": [
+        {
+          "id": "one",
+          "type": "book",
+          "title": "The Title",
+          "issued": {
+            "date-parts": [2000, 3, 10]
+          },
+          "approximate": "true"
+        }
+      ],
       "type": "object",
       "properties": {
         "date-parts": {
@@ -478,6 +489,20 @@
       "title": "Date Range",
       "description": "An EDTF range is a two-item array. An open end or begin of a range can be represented with an empty (date) object.",
       "type": "array",
+      "examples": [
+        {
+          "id": "range-1",
+          "type": "book",
+          "title": "The Title",
+          "issued": [{ "date-parts": [2000] }, { "date-parts": [2001] }]
+        },
+        {
+          "id": "range-2",
+          "type": "book",
+          "title": "The Title",
+          "issued": [{ "date-parts": [2000] }, {}]
+        }
+      ],
       "items": {
         "$ref": "#/definitions/date-object"
       },

--- a/schemas/input/csl-data.json
+++ b/schemas/input/csl-data.json
@@ -452,7 +452,9 @@
           "type": "book",
           "title": "The Title",
           "issued": {
-            "date-parts": [2000, 3, 10]
+            "year": 2000,
+            "month": 3,
+            "day": 10
           },
           "approximate": "true"
         }
@@ -462,13 +464,13 @@
         "year": {
           "title": "year",
           "description": "A year; can be negative.",
-          "examples": ["2012","-32"],
+          "examples": ["2012", "-32"],
           "type": "integer"
         },
         "month": {
           "title": "month",
           "description": "A month; can also represent seasons using the EDTF 21-24 values.",
-          "examples": ["2","22"],
+          "examples": ["2", "22"],
           "type": "integer"
         },
         "day": {
@@ -490,8 +492,21 @@
           "title": "Uncertain",
           "description": "Indicates uncertainty about a date representation, which may be presented as `May 23, 1972?`",
           "type": "boolean"
+        },
+        "undefined": {
+          "title": "Undefined",
+          "description": "Use to represent an open end of a range.",
+          "type": "boolean"
         }
-      }
+      },
+      "oneof": [
+        {
+          "required": ["year"]
+        },
+        {
+          "required": ["undefined"]
+        }
+      ]
     },
     "date-range": {
       "title": "Date Range",
@@ -502,13 +517,13 @@
           "id": "range-1",
           "type": "book",
           "title": "The Title",
-          "issued": [{ "date-parts": [2000] }, { "date-parts": [2001] }]
+          "issued": [{ "year": 2000 }, { "year": 2001 }]
         },
         {
           "id": "range-2",
           "type": "book",
           "title": "The Title",
-          "issued": [{ "date-parts": [2000] }, {}]
+          "issued": [{ "year": 2000 }, { "undefined": true }]
         }
       ],
       "items": {

--- a/schemas/input/csl-data.json
+++ b/schemas/input/csl-data.json
@@ -499,7 +499,7 @@
           "type": "boolean"
         }
       },
-      "oneof": [
+      "oneOf": [
         {
           "required": ["year"]
         },

--- a/schemas/input/csl-data.json
+++ b/schemas/input/csl-data.json
@@ -437,6 +437,78 @@
     "additionalProperties": false
   },
   "definitions": {
+    "edtf-string": {
+      "title": "EDTF date string",
+      "description": "CSL input supports EDTF, levels 0 and 1.",
+      "type": "string",
+      "pattern": "^[0-9-%~X?./]{4,}$"
+    },
+    "date-object": {
+      "title": "Date Object",
+      "description": "An EDTF date represented as an object.",
+      "type": "object",
+      "properties": {
+        "date-parts": {
+          "type": "array",
+          "items": {
+            "type": "integer"
+          },
+          "minItems": 1,
+          "maxItems": 3
+        },
+        "literal": {
+          "title": "Literal date",
+          "description": "A date that should be passed through to the processor as is; for dates that cannot be represented in EDTF.",
+          "examples": ["Han Dynasty"],
+          "type": "string"
+        },
+        "approximate": {
+          "title": "Approximate",
+          "description": "Indicates an approximate or circa date, which may be presented as `circa May 23, 1972`.",
+          "type": "boolean"
+        },
+        "uncertain": {
+          "title": "Uncertain",
+          "description": "Indicates uncertainty about a date representation, which may be presented as `May 23, 1972?`",
+          "type": "boolean"
+        }
+      },
+      "required": ["date-parts"]
+    },
+    "date-range": {
+      "title": "Date Range",
+      "description": "An EDTF range is a two-item array. An open end or begin of a range can be represented with a null.",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/date-object"
+      },
+      "minItems": 2,
+      "maxItems": 2
+    },
+    "date-structured": {
+      "title": "Structured Date",
+      "description": "Can either be an object, or a two-item array.",
+      "oneOf": [
+        {
+          "$ref": "#/definitions/date-object"
+        },
+        {
+          "$ref": "#/definitions/date-range"
+        }
+      ]
+    },
+    "date-variable": {
+      "title": "Date content model.",
+      "description": "The CSL input model supports two different date representations: an EDTF string (preferred), and a more structured alternative.",
+      "oneOf": [
+        {
+          "$ref": "#/definitions/edtf-string"
+        },
+        {
+          "$ref": "#/definitions/date-structured"
+        }
+      ]
+    },
     "name-variable": {
       "anyOf": [
         {
@@ -467,54 +539,6 @@
             },
             "parse-names": {
               "type": ["string", "number", "boolean"]
-            }
-          },
-          "additionalProperties": false
-        }
-      ]
-    },
-    "edtf-datatype": {
-      "title": "EDTF datatype pattern",
-      "description": "CSL input supports EDTF, validated against this regular expression.",
-      "type": "string",
-      "pattern": "^[0-9-%~X?.\/]{4,}$"
-    },
-    "date-variable": {
-      "title": "Date content model.",
-      "description": "The CSL input model supports two different date representations: an EDTF string (preferred), and a more structured alternative.",
-      "anyOf": [
-        {
-          "$ref": "#/definitions/edtf-datatype"
-        },
-        {
-          "properties": {
-            "date-parts": {
-              "type": "array",
-              "items": {
-                "type": "array",
-                "items": {
-                  "type": ["string", "number"]
-                },
-                "minItems": 1,
-                "maxItems": 3
-              },
-              "minItems": 1,
-              "maxItems": 2
-            },
-            "season": {
-              "type": ["string", "number"]
-            },
-            "circa": {
-              "type": ["string", "number", "boolean"]
-            },
-            "literal": {
-              "type": "string"
-            },
-            "raw": {
-              "type": "string"
-            },
-            "edtf": {
-              "$ref": "#/definitions/edtf-datatype"
             }
           },
           "additionalProperties": false

--- a/schemas/input/csl-data.json
+++ b/schemas/input/csl-data.json
@@ -487,7 +487,7 @@
     },
     "date-range": {
       "title": "Date Range",
-      "description": "An EDTF range is a two-item array. An open end or begin of a range can be represented with an empty (date) object.",
+      "description": "An EDTF range is a two-item array. An open end or beginning of a range can be represented with an empty (date) object.",
       "type": "array",
       "examples": [
         {

--- a/schemas/input/csl-data.json
+++ b/schemas/input/csl-data.json
@@ -459,13 +459,21 @@
       ],
       "type": "object",
       "properties": {
-        "date-parts": {
-          "type": "array",
-          "items": {
-            "type": "integer"
-          },
-          "minItems": 1,
-          "maxItems": 3
+        "year": {
+          "title": "year",
+          "description": "A year; can be negative.",
+          "examples": ["2012","-32"],
+          "type": "integer"
+        },
+        "month": {
+          "title": "month",
+          "description": "A month; can also represent seasons using the EDTF 21-24 values.",
+          "examples": ["2","22"],
+          "type": "integer"
+        },
+        "day": {
+          "title": "day",
+          "type": "integer"
         },
         "literal": {
           "title": "Literal date",

--- a/schemas/input/csl-data.json
+++ b/schemas/input/csl-data.json
@@ -472,12 +472,11 @@
           "description": "Indicates uncertainty about a date representation, which may be presented as `May 23, 1972?`",
           "type": "boolean"
         }
-      },
-      "required": ["date-parts"]
+      }
     },
     "date-range": {
       "title": "Date Range",
-      "description": "An EDTF range is a two-item array. An open end or begin of a range can be represented with a null.",
+      "description": "An EDTF range is a two-item array. An open end or begin of a range can be represented with an empty (date) object.",
       "type": "array",
       "items": {
         "$ref": "#/definitions/date-object"

--- a/tests/schemas/input/test_json.py
+++ b/tests/schemas/input/test_json.py
@@ -111,8 +111,8 @@ def test_basic_citation_schema_validates(csl_citation_validator):
 
 def test_basic_data_schema_with_author_validates(csl_data_validator):
     csl = [{
-        'id': 'example-id',
-        'type': 'report',
+        "id": "example-id",
+        "type": "report",
         "author": [
             {"given": "Jane", "family": "Roe"},
             {"literal": "John Doe"}
@@ -123,24 +123,22 @@ def test_basic_data_schema_with_author_validates(csl_data_validator):
 
 def test_data_schema_with_extra_property_fails(csl_data_validator):
     csl = [{
-        'id': 'example-id',
-        'type': 'report',
-        'not-a-csl-key': None,
+        "id": "example-id",
+        "type": "report",
+        "not-a-csl-key": None,
     }]
     with pytest.raises(jsonschema.exceptions.ValidationError):
         csl_data_validator.validate(csl)
 
-def test_data_schema_with_empty_date_parts(csl_data_validator):
+def test_data_schema_with_missing_date(csl_data_validator):
     """
-    empty arrays in date-parts can cause downstream citeproc failures
+    empty dates can cause downstream citeproc failures
     https://github.com/citation-style-language/schema/pull/158
     """
     csl = [{
-        'id': 'example-id',
-        'type': 'report',
-        'issued': {
-            "date-parts": []
-        },
+        "id": "example-id",
+        "type": "report",
+        "issued": { 'approximate': true }
     }]
     with pytest.raises(jsonschema.exceptions.ValidationError):
         csl_data_validator.validate(csl)

--- a/tests/schemas/input/test_json.py
+++ b/tests/schemas/input/test_json.py
@@ -130,15 +130,3 @@ def test_data_schema_with_extra_property_fails(csl_data_validator):
     with pytest.raises(jsonschema.exceptions.ValidationError):
         csl_data_validator.validate(csl)
 
-def test_data_schema_with_missing_date(csl_data_validator):
-    """
-    empty dates can cause downstream citeproc failures
-    https://github.com/citation-style-language/schema/pull/158
-    """
-    csl = [{
-        "id": "example-id",
-        "type": "report",
-        "issued": { "approximate": true }
-    }]
-    with pytest.raises(jsonschema.exceptions.ValidationError):
-        csl_data_validator.validate(csl)

--- a/tests/schemas/input/test_json.py
+++ b/tests/schemas/input/test_json.py
@@ -139,7 +139,7 @@ def test_data_schema_with_missing_date(csl_data_validator):
         'id': 'example-id',
         'type': 'report',
         'issued': {
-            'approximate': true
+            'approximate': 'true'
         },
     }]
     with pytest.raises(jsonschema.exceptions.ValidationError):

--- a/tests/schemas/input/test_json.py
+++ b/tests/schemas/input/test_json.py
@@ -138,7 +138,7 @@ def test_data_schema_with_missing_date(csl_data_validator):
     csl = [{
         "id": "example-id",
         "type": "report",
-        "issued": { 'approximate': true }
+        "issued": { "approximate": true }
     }]
     with pytest.raises(jsonschema.exceptions.ValidationError):
         csl_data_validator.validate(csl)

--- a/tests/schemas/input/test_json.py
+++ b/tests/schemas/input/test_json.py
@@ -139,7 +139,7 @@ def test_data_schema_with_missing_date(csl_data_validator):
         'id': 'example-id',
         'type': 'report',
         'issued': {
-            'approximate': 'true'
+            'approximate': True
         },
     }]
     with pytest.raises(jsonschema.exceptions.ValidationError):

--- a/tests/schemas/input/test_json.py
+++ b/tests/schemas/input/test_json.py
@@ -130,3 +130,17 @@ def test_data_schema_with_extra_property_fails(csl_data_validator):
     with pytest.raises(jsonschema.exceptions.ValidationError):
         csl_data_validator.validate(csl)
 
+def test_data_schema_with_missing_date(csl_data_validator):
+    """
+    empty dates can cause downstream citeproc failures
+    https://github.com/citation-style-language/schema/pull/158
+    """
+    csl = [{
+        'id': 'example-id',
+        'type': 'report',
+        'issued': {
+            'approximate': true
+        },
+    }]
+    with pytest.raises(jsonschema.exceptions.ValidationError):
+        csl_data_validator.validate(csl)

--- a/tests/schemas/input/test_json.py
+++ b/tests/schemas/input/test_json.py
@@ -116,7 +116,7 @@ def test_basic_data_schema_with_author_validates(csl_data_validator):
         "author": [
             {"given": "Jane", "family": "Roe"},
             {"literal": "John Doe"}
-        ],
+        ]
     }]
     csl_data_validator.validate(csl)
 
@@ -125,7 +125,7 @@ def test_data_schema_with_extra_property_fails(csl_data_validator):
     csl = [{
         "id": "example-id",
         "type": "report",
-        "not-a-csl-key": None,
+        "not-a-csl-key": None
     }]
     with pytest.raises(jsonschema.exceptions.ValidationError):
         csl_data_validator.validate(csl)


### PR DESCRIPTION
This modifies the structured date object to align with the EDTF model.

It moves the qualifiers to the date object, and then defines a date
range as an array of these date objects.

The result is that dates can either be represented as an EDTF string, 
or as a structured object date, or a date range array.

The intention is this structured variant will go away in time, so that 
in the future the only option will be the EDTF string.

Closes #300 

-----

In CSL JSON 1.0, dates are either a two-level nested array ...

``` js
  "issued": {
    "date-parts": [
      [
        2000,
        3,
        15
      ],
      [
        2000,
        3,
        17
      ]
    ],
    "circa": "true"
  }
```

... or a `raw` string, with is a standard EDTF-like date (note, however, that the example isn't compliant because months are not two-digits, as they are in ISO 8601).

``` js
"accessed": {
     "raw": "2005-4-12"
},
"issued": {
     "raw": "2000-3-15/2000-3-17"
}
```

In CSL JSON 1.1, we move `raw` to an explicit EDTF string option on the property itself,

So in this option, the above becomes:

``` js
"accessed": "2005-4-12",
"issued":  "2000-3-15/2000-3-17"
```

This PR defines:

1. a date as an object, and moves the qualifiers onto the object, to make it consistent with EDTF (where you can have different qualifiers on the begin and end of a range)
2. a date range as a a two-item array of date objects

A single date would be:

``` js
  "issued": {
      "date-parts": [
        2000,
        3,
        15
      ],
      "approximate": "true"
    }
```

... and the first range example becomes this ("approximate" is the EDTF language what we have called "circa"):

``` js
  "issued": [
    {
      "date-parts": [
        2000,
        3,
        15
      ]
    },
    {
      "date-parts": [
        2000,
        3,
        17
      ]
    }
  ]
```
Note: open question is how to handle the mismatch between circa on 1.0 and this.

And we can then do things like season ranges (not formally supported by EDTF, but easy for us to add):

``` js
  "issued": [
    {
      "date-parts": [
        2000,
        21
      ]
    },
    {
      "date-parts": [
        2000,
        22
      ]
    }
  ]
```

This would seem a better long-term that would allow us to painlessly drop the object/array representation at some point in the future.