### PR TITLE
add new page-range formats

### DIFF
--- a/schemas/styles/csl.rnc
+++ b/schemas/styles/csl.rnc
@@ -760,7 +760,7 @@ div {
     
     ## Reformat page ranges in the "page" variable.
     attribute page-range-format {
-      "chicago" | "expanded" | "minimal" | "minimal-two"
+      "chicago" | "mhra" | "expanded" | "minimal" | "minimal-two" | "minimal-oup"
     }?
   citation.cite-group-delimiter =
     

--- a/schemas/styles/csl.rnc
+++ b/schemas/styles/csl.rnc
@@ -760,7 +760,7 @@ div {
     
     ## Reformat page ranges in the "page" variable.
     attribute page-range-format {
-      "chicago" | "mhra" | "expanded" | "minimal" | "minimal-two" | "minimal-oup"
+      "expanded" | "minimal" | "minimal-two" | "minimal-oup" | "chicago" | "mhra" 
     }?
   citation.cite-group-delimiter =
     


### PR DESCRIPTION
## Description

There same to be more page range formats than the one that we currently support. E.g. (as per #123):

* The [MHRA format](http://www.mhra.org.uk/Publications/Books/StyleGuide/StyleGuideV3_1.pdf) (see p. 47 of the guide), which is like `chicago` but wants a leading zero, e.g. 13–15, 44–47, 100–22, 104–08, 1933–39 but 1098–1101.
* The [OUP format](http://global.oup.com/uk/academic/authors/AuthorGuidelinesMain/HouseStyle/#lev20), which is like the `minimal` style but requests, 'Do not omit digits between 10 and 19 in any hundred.’ I believe this is supposed to fit with English pronunciation (cf. a [similar style guide](http://www.pims.ca/pdf/bw-stylesheet.pdf)).

Closes #123 

## Type of change

- [X] New feature (non-breaking change which adds functionality)
- [X] This change requires a documentation update

## Checklist

- [X] I have installed the repo [pre-commit hook](https://github.com/citation-style-language/schema/blob/master/CONTRIBUTING.md#pre-commit-hooks); if not, and I have modified any of the schema files, I have run trang and/or prettier on the files, per [CONTRIBUTING](https://github.com/citation-style-language/schema/blob/master/CONTRIBUTING.md)
- [X] I have performed a self-review of my own code
- [] I have included suggested corresponding changes to the documentation (if relevant)
