### PR TITLE
Add conditional logic to terms

### DIFF
--- a/schemas/styles/csl.rnc
+++ b/schemas/styles/csl.rnc
@@ -293,7 +293,7 @@ div {
   ## When specifying conditions, we allow either the attribute syntax or the element-based one.
   terms.term.choose.condition =
     (terms.term.condition.atts, match?)
-    | element cs:conditions { match,  terms.term.choose.condition.elem }
+    | element cs:conditions { match?,  terms.term.choose.condition.elem }
   terms.term.choose.if = element cs:if { terms.term.choose.condition,  terms.term.elem }
   terms.term.choose.else-if =
     element cs:else-if { terms.term.choose.condition,  terms.term.elem }

--- a/schemas/styles/csl.rnc
+++ b/schemas/styles/csl.rnc
@@ -276,11 +276,37 @@ div {
   
   ## The "cs:term" element can either hold a basic string, or "cs:single" and
   ## "cs:multiple" child elements to give singular and plural forms of the term.
+  ## To conditionally define terms use "cs:choose" as child element of "cs:term".
+
   terms.term =
     element cs:term {
-      term.attributes,
-      (text | (term.single, term.multiple))
+      term.attributes, (terms.term.elem | terms.term.choose)
     }
+
+  terms.term.elem = text | (term.single, term.multiple)
+
+  terms.term.choose =
+
+    ## Used to conditionally define terms.
+    element cs:choose { terms.term.choose.if, terms.term.choose.else-if*, terms.term.choose.else? }
+  
+  ## When specifying conditions, we allow either the attribute syntax or the element-based one.
+  terms.term.choose.condition =
+    (terms.term.condition.atts, match?)
+    | element cs:conditions { match,  terms.term.choose.condition.elem }
+  terms.term.choose.if = element cs:if { terms.term.choose.condition,  terms.term.elem }
+  terms.term.choose.else-if =
+    element cs:else-if { terms.term.choose.condition,  terms.term.elem }
+  terms.term.choose.else = element cs:else { terms.term.elem }
+
+  terms.term.choose.condition.elem = element cs:condition { match?, terms.term.condition.atts }
+
+  terms.term.condition.atts = 
+    ## Tests whether the item matches the given types.
+    attribute type {
+      list { item-types+ }
+    }
+
   term.attributes =
     (attribute name { terms },
      [ a:defaultValue = "long" ] attribute form { term.form }?)


### PR DESCRIPTION
## Description

As per https://github.com/citation-style-language/schema/issues/282#issue-646718876:
Some languages have multiple forms for a term depending on the item type (usually books versus journals). For example, [Turkish](https://forums.zotero.org/discussion/81900/is-it-possible-different-ibid-term-for-books-article-and-web-page#latest) uses different phrases for "ibid" for books vs. journals. [German](https://github.com/citation-style-language/csl-evolution/issues/34) uses different words for "volume" for books vs. journals.

This allows `cs:choose` as a child element of `cs:term`.

Fixes #282 

## Question?

Should we allow other tests as well? Some of them/all of them?

I admit the current definition is overly complex as it follow the new pattern for conditions. This is unnecessary given that this currently only allows testing for item type. Even with more tests the pattern is ridiculously complex. We could probably simplify to

```xml
<term name="volume>
  <if type="article>asdf</if>
  <else>jklö</else>
<term>
```

But that would only increase complexity on another level, as the processor would now have to process two different conditional structures.

## Type of change

Please delete options that are not relevant.

- [X] New feature (non-breaking change which adds functionality)
- [X] This change requires a documentation update

## Checklist

- [X] I have installed the repo [pre-commit hook](https://github.com/citation-style-language/schema/blob/master/CONTRIBUTING.md#pre-commit-hooks); if not, and I have modified any of the schema files, I have run trang and/or prettier on the files, per [CONTRIBUTING](https://github.com/citation-style-language/schema/blob/master/CONTRIBUTING.md)
- [X] I have performed a self-review of my own code
- [] I have included suggested corresponding changes to the documentation (if relevant)
