### PR TITLE
add @types to terms

### DIFF
--- a/schemas/styles/csl.rnc
+++ b/schemas/styles/csl.rnc
@@ -283,24 +283,31 @@ div {
     }
   term.attributes =
     (attribute name { terms },
-     [ a:defaultValue = "long" ] attribute form { term.form }?)
+     [ a:defaultValue = "long" ] attribute form { term.form }?,
+     term.types)
     | (attribute name { terms.ordinals },
        attribute form { "long" }?,
        attribute gender-form { "masculine" | "feminine" }?,
        attribute match {
          "last-digit" | "last-two-digits" | "whole-number"
-       }?)
+       }?,
+       term.types)
     | (attribute name { terms.long-ordinals },
        attribute form { "long" }?,
        attribute gender-form { "masculine" | "feminine" })
     | (attribute name { terms.gender-assignable },
        attribute form { "long" }?,
-       attribute gender { "masculine" | "feminine" })
+       attribute gender { "masculine" | "feminine" },
+       term.types)
   
   ## "verb-short" reverts to "verb" if the "verb-short" form is not available.
   ## "symbol" reverts to "short" if the "symbol" form is not available.
   ## "verb" and "short" revert to "long" if the specified form is not available.
   term.form = "long" | "verb" | "short" | "verb-short" | "symbol"
+  term.types = 
+    attribute types {
+        list { item-types+ }
+      }
   term.single =
     
     ## Singular version of the term.

--- a/schemas/styles/csl.rnc
+++ b/schemas/styles/csl.rnc
@@ -304,10 +304,11 @@ div {
   ## "symbol" reverts to "short" if the "symbol" form is not available.
   ## "verb" and "short" revert to "long" if the specified form is not available.
   term.form = "long" | "verb" | "short" | "verb-short" | "symbol"
-  term.types = 
+  # Used to specify terms per item type
+  term.types =
     attribute for-types {
-        list { item-types+ }
-      }
+      list { item-types+ }
+    }
   term.single =
     
     ## Singular version of the term.
@@ -767,7 +768,12 @@ div {
     
     ## Reformat page ranges in the "page" variable.
     attribute page-range-format {
-      "expanded" | "minimal" | "minimal-two" | "minimal-oup" | "chicago" | "mhra" 
+      "expanded"
+      | "minimal"
+      | "minimal-two"
+      | "minimal-oup"
+      | "chicago"
+      | "mhra"
     }?
   citation.cite-group-delimiter =
     

--- a/schemas/styles/csl.rnc
+++ b/schemas/styles/csl.rnc
@@ -305,7 +305,7 @@ div {
   ## "verb" and "short" revert to "long" if the specified form is not available.
   term.form = "long" | "verb" | "short" | "verb-short" | "symbol"
   term.types = 
-    attribute types {
+    attribute for-types {
         list { item-types+ }
       }
   term.single =


### PR DESCRIPTION
## Description

Alternative PR to #306

Some languages have multiple forms for a term depending on the item type (usually books versus journals). For example, Turkish uses different phrases for "ibid" for books vs. journals. German uses different words for "volume" for books vs. journals.

Instead of using the standard `cs:choose` syntax this PR just adds a new attribute `types` to be used with term definitions.

In styles or locale files this will be used like this:

```xml
<terms>
  <term name="volume" types="article article-journal article-magazine article-newspaper">a term</term>
  <term name="volume">another term</term>
</terms>
```

Fixes #282 (issue)

## Type of change

Please delete options that are not relevant.

- [X] New feature (non-breaking change which adds functionality)
- [X] This change requires a documentation update

## Checklist

- [X] I have installed the repo [pre-commit hook](https://github.com/citation-style-language/schema/blob/master/CONTRIBUTING.md#pre-commit-hooks); if not, and I have modified any of the schema files, I have run trang and/or prettier on the files, per [CONTRIBUTING](https://github.com/citation-style-language/schema/blob/master/CONTRIBUTING.md)
- [X] I have performed a self-review of my own code
- [] I have included suggested corresponding changes to the documentation (if relevant)
