### PR TITLE
input: rich text

### DIFF
--- a/schemas/input/csl-data.json
+++ b/schemas/input/csl-data.json
@@ -221,10 +221,10 @@
         "$ref": "#/definitions/date-variable"
       },
       "abstract": {
-        "type": "string"
+        "$ref": "#/definitions/rich-text-string"
       },
       "annote": {
-        "type": "string"
+        "$ref": "#/definitions/rich-text-string"
       },
       "archive": {
         "type": "string"
@@ -257,13 +257,13 @@
         "type": ["string", "number"]
       },
       "collection-title": {
-        "type": "string"
+        "$ref": "#/definitions/title-string"
       },
       "container-title": {
-        "type": "string"
+        "$ref": "#/definitions/title-string"
       },
       "container-title-short": {
-        "type": "string"
+        "$ref": "#/definitions/title-string"
       },
       "dimensions": {
         "type": "string"
@@ -344,7 +344,7 @@
         "type": "string"
       },
       "original-title": {
-        "type": "string"
+        "$ref": "#/definitions/title-string"
       },
       "page": {
         "type": ["string", "number"]
@@ -356,7 +356,7 @@
         "type": ["string", "number"]
       },
       "part-title": {
-        "type": "string"
+        "$ref": "#/definitions/title-string"
       },
       "PMCID": {
         "type": "string"
@@ -377,7 +377,7 @@
         "type": "string"
       },
       "reviewed-title": {
-        "type": "string"
+        "$ref": "#/definitions/title-string"
       },
       "scale": {
         "type": "string"
@@ -395,16 +395,16 @@
         "type": ["string", "number"]
       },
       "title": {
-        "type": "string"
+        "$ref": "#/definitions/title-string"
       },
       "title-short": {
-        "type": "string"
+        "$ref": "#/definitions/title-string"
       },
       "translated-title": {
-        "type": "string"
+        "$ref": "#/definitions/title-string"
       },
       "translated-title-short": {
-        "type": "string"
+        "$ref": "#/definitions/title-string"
       },
       "URL": {
         "type": "string"
@@ -437,6 +437,16 @@
     "additionalProperties": false
   },
   "definitions": {
+    "rich-text-string": {
+      "title": "Rich Text String",
+      "description": "A string that may include sub-string formatting for bold, italic, subscript, superscript, math, etc. The accompanying `csl-rich-text.yaml` schema defines experimental support for this in CSL JSON input.",
+      "type": "string"
+    },
+    "title-string": {
+      "title": "Title String",
+      "description": "Titles are a primary example of rich text strings in CSL.",
+      "$ref": "#definitions/rich-text-string"
+    },
     "edtf-string": {
       "title": "EDTF date string",
       "description": "CSL input supports EDTF, levels 0 and 1.",

--- a/schemas/input/csl-rich-text.yaml
+++ b/schemas/input/csl-rich-text.yaml
@@ -1,0 +1,54 @@
+---
+description: JSON schema for CSL input rich text representation
+"$schema": http://json-schema.org/draft-07/schema#
+"$id": https://resource.citationstyles.org/schema/latest/input/json/csl-rich-text.json
+definitions:
+  rich-text-content:
+    title: Rich Text Content
+    description: Rich text content can be represented as an array of strings and formatted object strings.
+    examples:
+      - title:
+          - A title with a
+          - quote: quoted string.
+      - title:
+          - A title with tex math
+          - math-tex: x=y^2
+      - title:
+          - A title with mathml
+          - math-ml: x=y^2
+    oneOf:
+      - "$ref": "#/definitions/rich-text"
+      - type: string
+  rich-text:
+    type: array
+    items:
+      anyOf:
+        - title: Unformatted Sub-String
+          type: string
+        - bold:
+            title: Bold Text
+            "#ref": "#/definitions/rich-text-content"
+        - code:
+            title: Code/Verbatim Text
+            "#ref": "#/definitions/rich-text-content"
+        - italic:
+            title: Italicized Text
+            "#ref": "#/definitions/rich-text-content"
+        - math-ml:
+            title: MathML
+            "#ref": "#/definitions/rich-text-content"
+        - math-tex:
+            title: Math-TeX
+            "#ref": "#/definitions/rich-text-content"
+        - preserve:
+            title: Preserve Case Text
+            "#ref": "#/definitions/rich-text-content"
+        - quote:
+            title: Quote
+            "#ref": "#/definitions/rich-text-content"
+        - sc:
+            title: Small-Cap Text
+            "#ref": "#/definitions/rich-text-content"
+        - strike:
+            title: Strike-Through Text
+            "#ref": "#/definitions/rich-text-content"


### PR DESCRIPTION
## Description

This adds support for rich-text handling to the JSON schema, by defining new formatted string objects, that can be mixed with strings in an array.

Note that I have been conservative on where I allow rich-text formatting. I don't think we should allow it everywhere, and I think we should only explicitly allow it where it make sense.

## Type of change

- [X] This is a breaking change
- [X] This change requires a documentation update

cc @jgm