### PR TITLE
Add YAML schema, workflow to publish json schema, docs

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -13,7 +13,7 @@ jobs:
         run: |
           npm install js-yaml
           # pip install json-schema-for-humans
-          # js-yaml schemas/input/csl-data.yaml > schemas/input/latest/csl-data.json # currently leave off, as no yaml file
+          js-yaml schemas/input/csl-data.yaml > schemas/input/latest/csl-data.json # currently leave off, as no yaml file
           # TODO generate-schema-doc -–deprecated-from-description schemas/input/csl-data.yaml build/csl-data/index.html
 
       - name: Deploy 🚀

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,0 +1,24 @@
+name: Publish
+on: [push]
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout 🛎️
+        uses: actions/checkout@v2 # If you're using actions/checkout@v2 you must set persist-credentials to false in most cases for the deployment to work correctly.
+        with:
+          persist-credentials: false
+
+      - name: Install and Build 🔧 # convert the yaml schema to json version and docs, and publish on gh-pages
+        run: |
+          npm install js-yaml
+          # pip install json-schema-for-humans
+          # js-yaml schemas/input/csl-data.yaml > schemas/input/latest/csl-data.json # currently leave off, as no yaml file
+          # TODO generate-schema-doc -–deprecated-from-description schemas/input/csl-data.yaml build/csl-data/index.html
+
+      - name: Deploy 🚀
+        uses: JamesIves/github-pages-deploy-action@releases/v3
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BRANCH: gh-pages # The branch the action should deploy to.
+          FOLDER: schemas/input/latest # The folder the action should deploy.

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -13,6 +13,7 @@ jobs:
         run: |
           npm install js-yaml
           # pip install json-schema-for-humans
+          mkdir schemas/input/latest
           js-yaml schemas/input/csl-data.yaml > schemas/input/latest/csl-data.json # currently leave off, as no yaml file
           # TODO generate-schema-doc -–deprecated-from-description schemas/input/csl-data.yaml build/csl-data/index.html
 

--- a/schemas/input/csl-data.yaml
+++ b/schemas/input/csl-data.yaml
@@ -1,0 +1,476 @@
+description: JSON schema for CSL input data
+$schema: http://json-schema.org/draft-07/schema#
+$id: https://resource.citationstyles.org/schema/latest/input/json/csl-data.json
+type: array
+items:
+  type: object
+  properties:
+    type:
+      type: string
+      enum:
+      - article
+      - article-journal
+      - article-magazine
+      - article-newspaper
+      - bill
+      - book
+      - broadcast
+      - chapter
+      - classic
+      - collection
+      - dataset
+      - document
+      - entry
+      - entry-dictionary
+      - entry-encyclopedia
+      - figure
+      - graphic
+      - hearing
+      - interview
+      - legal_case
+      - legislation
+      - manuscript
+      - map
+      - motion_picture
+      - musical_score
+      - pamphlet
+      - paper-conference
+      - patent
+      - performance
+      - periodical
+      - personal_communication
+      - post
+      - post-weblog
+      - regulation
+      - report
+      - review
+      - review-book
+      - software
+      - song
+      - speech
+      - standard
+      - thesis
+      - treaty
+      - webpage
+    id:
+      type:
+      - string
+      - number
+    categories:
+      type: array
+      items:
+        type: string
+    language:
+      type: string
+    journalAbbreviation:
+      type: string
+    shortTitle:
+      type: string
+    author:
+      type: array
+      items:
+        $ref: '#/definitions/name-variable'
+    chair:
+      type: array
+      items:
+        $ref: '#/definitions/name-variable'
+    collection-editor:
+      type: array
+      items:
+        $ref: '#/definitions/name-variable'
+    compiler:
+      type: array
+      items:
+        $ref: '#/definitions/name-variable'
+    composer:
+      type: array
+      items:
+        $ref: '#/definitions/name-variable'
+    container-author:
+      type: array
+      items:
+        $ref: '#/definitions/name-variable'
+    contributor:
+      type: array
+      items:
+        $ref: '#/definitions/name-variable'
+    curator:
+      type: array
+      items:
+        $ref: '#/definitions/name-variable'
+    director:
+      type: array
+      items:
+        $ref: '#/definitions/name-variable'
+    editor:
+      type: array
+      items:
+        $ref: '#/definitions/name-variable'
+    editorial-director:
+      type: array
+      items:
+        $ref: '#/definitions/name-variable'
+    executive-producer:
+      type: array
+      items:
+        $ref: '#/definitions/name-variable'
+    interviewer:
+      type: array
+      items:
+        $ref: '#/definitions/name-variable'
+    illustrator:
+      type: array
+      items:
+        $ref: '#/definitions/name-variable'
+    organizer:
+      type: array
+      items:
+        $ref: '#/definitions/name-variable'
+    original-author:
+      type: array
+      items:
+        $ref: '#/definitions/name-variable'
+    performer:
+      type: array
+      items:
+        $ref: '#/definitions/name-variable'
+    producer:
+      type: array
+      items:
+        $ref: '#/definitions/name-variable'
+    recipient:
+      type: array
+      items:
+        $ref: '#/definitions/name-variable'
+    reviewed-author:
+      type: array
+      items:
+        $ref: '#/definitions/name-variable'
+    translator:
+      type: array
+      items:
+        $ref: '#/definitions/name-variable'
+    accessed:
+      $ref: '#/definitions/date-variable'
+    available-date:
+      $ref: '#/definitions/date-variable'
+    container:
+      $ref: '#/definitions/date-variable'
+    event-date:
+      $ref: '#/definitions/date-variable'
+    issued:
+      $ref: '#/definitions/date-variable'
+    original-date:
+      $ref: '#/definitions/date-variable'
+    submitted:
+      $ref: '#/definitions/date-variable'
+    abstract:
+      type: string
+    annote:
+      type: string
+    archive:
+      type: string
+    archive_collection:
+      type: string
+    archive_location:
+      type: string
+    archive-place:
+      type: string
+    authority:
+      type: string
+    call-number:
+      type: string
+    chapter-number:
+      type:
+      - string
+      - number
+    citation-number:
+      type:
+      - string
+      - number
+    citation-label:
+      type: string
+    collection-number:
+      type:
+      - string
+      - number
+    collection-title:
+      type: string
+    container-title:
+      type: string
+    container-title-short:
+      type: string
+    dimensions:
+      type: string
+    division:
+      type: string
+    DOI:
+      type: string
+    edition:
+      type:
+      - string
+      - number
+    event:
+      type: string
+    event-place:
+      type: string
+    first-reference-note-number:
+      type:
+      - string
+      - number
+    genre:
+      type: string
+    ISAN:
+      type: string
+    ISBN:
+      type: string
+    ISCI:
+      type: string
+    ISMN:
+      type: string
+    ISRC:
+      type: string
+    ISSN:
+      type: string
+    ISWC:
+      type: string
+    issue:
+      type:
+      - string
+      - number
+    jurisdiction:
+      type: string
+    keyword:
+      type: string
+    locator:
+      type:
+      - string
+      - number
+    medium:
+      type: string
+    note:
+      type: string
+    number:
+      type:
+      - string
+      - number
+    number-of-pages:
+      type:
+      - string
+      - number
+    number-of-volumes:
+      type:
+      - string
+      - number
+    original-publisher:
+      type: string
+    original-publisher-place:
+      type: string
+    original-title:
+      type: string
+    page:
+      type:
+      - string
+      - number
+    page-first:
+      type:
+      - string
+      - number
+    part:
+      type:
+      - string
+      - number
+    part-title:
+      type: string
+    PMCID:
+      type: string
+    PMID:
+      type: string
+    printing:
+      type:
+      - string
+      - number
+    publisher:
+      type: string
+    publisher-place:
+      type: string
+    references:
+      type: string
+    reviewed-title:
+      type: string
+    scale:
+      type: string
+    section:
+      type: string
+    source:
+      type: string
+    status:
+      type: string
+    supplement:
+      type:
+      - string
+      - number
+    title:
+      type: string
+    title-short:
+      type: string
+    translated-title:
+      type: string
+    translated-title-short:
+      type: string
+    URL:
+      type: string
+    version:
+      type: string
+    volume:
+      type:
+      - string
+      - number
+    year-suffix:
+      type: string
+    custom:
+      title: Custom key-value pairs.
+      type: object
+      description: Used to store additional information that does not have a designated
+        CSL JSON field. The note field can also store additional information, but
+        custom is preferred for storing key-value pairs.
+      examples:
+      - short_id: xyz
+        other-ids:
+        - alternative-id
+      - metadata-double-checked: true
+  required:
+  - type
+  - id
+  additionalProperties: false
+definitions:
+  edtf-string:
+    title: EDTF date string
+    description: CSL input supports EDTF, levels 0 and 1.
+    type: string
+    pattern: ^[0-9-%~X?./]{4,}$
+  date-object:
+    title: Date Object
+    description: An EDTF date represented as an object. Seasons can be represented
+      using the 21-24 month values of EDTF, decades and centuries using the X notation,
+      and the qualifiers with the included boolean properties
+    examples:
+    - id: one
+      type: book
+      title: The Title
+      issued:
+        year: 2000
+        month: 3
+        day: 10
+      approximate: 'true'
+    type: object
+    properties:
+      year:
+        title: year
+        description: A year; can be negative.
+        examples:
+        - '2012'
+        - '-32'
+        type: integer
+      month:
+        title: month
+        description: A month; can also represent seasons using the EDTF 21-24 values.
+        examples:
+        - '2'
+        - '22'
+        type: integer
+      day:
+        title: day
+        type: integer
+      literal:
+        title: Literal date
+        description: A date that should be passed through to the processor as is;
+          for dates that cannot be represented in EDTF.
+        examples:
+        - Han Dynasty
+        type: string
+      approximate:
+        title: Approximate
+        description: Indicates an approximate or circa date, which may be presented
+          as `circa May 23, 1972`.
+        type: boolean
+      uncertain:
+        title: Uncertain
+        description: Indicates uncertainty about a date representation, which may
+          be presented as `May 23, 1972?`
+        type: boolean
+      undefined:
+        title: Undefined
+        description: Use to represent an open end of a range.
+        type: boolean
+    oneOf:
+    - required:
+      - year
+    - required:
+      - undefined
+  date-range:
+    title: Date Range
+    description: An EDTF range is a two-item array. An open end or beginning of a
+      range can be represented with an empty (date) object.
+    type: array
+    examples:
+    - id: range-1
+      type: book
+      title: The Title
+      issued:
+      - year: 2000
+      - year: 2001
+    - id: range-2
+      type: book
+      title: The Title
+      issued:
+      - year: 2000
+      - undefined: true
+    items:
+      $ref: '#/definitions/date-object'
+    minItems: 2
+    maxItems: 2
+  date-structured:
+    title: Structured Date
+    description: Can either be an object, or a two-item array.
+    oneOf:
+    - $ref: '#/definitions/date-object'
+    - $ref: '#/definitions/date-range'
+  date-variable:
+    title: Date content model.
+    description: 'The CSL input model supports two different date representations:
+      an EDTF string (preferred), and a more structured alternative.'
+    oneOf:
+    - $ref: '#/definitions/edtf-string'
+    - $ref: '#/definitions/date-structured'
+  name-variable:
+    anyOf:
+    - properties:
+        family:
+          type: string
+        given:
+          type: string
+        dropping-particle:
+          type: string
+        non-dropping-particle:
+          type: string
+        suffix:
+          type: string
+        comma-suffix:
+          type:
+          - string
+          - number
+          - boolean
+        static-ordering:
+          type:
+          - string
+          - number
+          - boolean
+        literal:
+          type: string
+        parse-names:
+          type:
+          - string
+          - number
+          - boolean
+      additionalProperties: false

--- a/tools/yaml2json.py
+++ b/tools/yaml2json.py
@@ -1,0 +1,20 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+import ruamel.yaml
+import json
+import glob
+import sys
+import os
+
+# grab the yaml files
+files = glob.glob('schemas/input/csl-*.yaml')
+
+for file in files:
+    ofn = os.path.join('build', os.path.splitext(file)[0] + '.json')
+    print(ofn)
+    yaml = ruamel.yaml.YAML(typ='safe')
+
+    with open(file) as jsonf:
+        data = yaml.load(jsonf)
+    with open(ofn, 'w') as fpo:
+        json.dump(data, fpo, indent=2)

--- a/tools/yaml2json.py
+++ b/tools/yaml2json.py
@@ -7,14 +7,14 @@ import glob
 import sys
 
 # grab the yaml files
-files = glob.glob('schemas/input/csl-*.yaml')
+yfiles = glob.glob('schemas/input/csl-*.yaml')
 
-for file in files:
-    ofns = Path(file).stem
-    ofn = ofns + '.json'
+for yfile in yfiles:
+    inf = Path(yfile)
+    ofns = inf.stem
+    ofn = Path('build/' + ofns + '.json')
     yaml = ruamel.yaml.YAML(typ='safe')
-
-    with open(file) as jsonf:
-        data = yaml.load(jsonf)
-    with open(ofn, 'w') as fpo:
-        json.dump(data, fpo, indent=2)
+    data = yaml.load(inf)
+    with open(ofn, "w") as write_file:
+        json.dump(data, write_file)
+    #json.dump(data, ofn, indent=2)

--- a/tools/yaml2json.py
+++ b/tools/yaml2json.py
@@ -1,17 +1,17 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 import ruamel.yaml
+from pathlib import Path
 import json
 import glob
 import sys
-import os
 
 # grab the yaml files
 files = glob.glob('schemas/input/csl-*.yaml')
 
 for file in files:
-    ofn = os.path.join('build', os.path.splitext(file)[0] + '.json')
-    print(ofn)
+    ofns = Path(file).stem
+    ofn = ofns + '.json'
     yaml = ruamel.yaml.YAML(typ='safe')
 
     with open(file) as jsonf:

--- a/tools/yaml2json.py
+++ b/tools/yaml2json.py
@@ -16,5 +16,4 @@ for yfile in yfiles:
     yaml = ruamel.yaml.YAML(typ='safe')
     data = yaml.load(inf)
     with open(ofn, "w") as write_file:
-        json.dump(data, write_file)
-    #json.dump(data, ofn, indent=2)
+        json.dump(data, write_file, indent=2)


### PR DESCRIPTION
Add new YAML version of the data schema (citation schema to come), and beginning of workflow 
to convert YAML schema to JSON and publish on GitHub pages.

Goal is for the documentation to be published in the same workflow.

Still to settle:

1. folder structure vis-a-vis versions? currently it's `input/1.0/csl-data.json`, for example
2. update id? do we need the redirect? if the schema is yaml and json, should the id have an extension?
3. the action is failing with a command not found error, after success on installing the command
4. python setup
5. do I `git rm` for the json files, or `git mv`?

Closes #316.