### PR TITLE
input: Change titles to objects

### DIFF
--- a/schemas/input/csl-data.json
+++ b/schemas/input/csl-data.json
@@ -20,20 +20,22 @@
         {
           "full": "Finis Coronat Opus: A Curious Reciprocity; Shelley’s “When the Lamp Is Shattered”",
           "main": "Finis Coronat Opus",
-          "sub": "A Curious Reciprocity",
-          "sub-sub": "Shelley’s “When the Lamp Is Shattered”"
+          "sub": [
+            "A Curious Reciprocity",
+            "Shelley’s “When the Lamp Is Shattered”"
+          ]
         },
         {
           "main": "Whose Music?",
-          "sub": "A Sociology of Musical Language"
+          "sub": ["A Sociology of Musical Language"]
         },
         {
           "main": "Pardon the Interruption",
-          "sub": "Goal Proximity, Perceived Spare Time, and Impatience"
+          "sub": ["Goal Proximity, Perceived Spare Time, and Impatience"]
         },
         {
           "main": "England’s Monitor",
-          "alternate": "The History of the Separation"
+          "sub": [", or The History of the Separation"]
         },
         {
           "main": "Kriegstagebuch des Oberkommandos der Wehrmacht, 1940–1945",

--- a/schemas/input/csl-data.json
+++ b/schemas/input/csl-data.json
@@ -51,16 +51,6 @@
           "description": "The primary title component for the item.",
           "$ref": "#definitions/rich-text-string"
         },
-        "sub": {
-          "title": "Sub-Title",
-          "description": "The sub-title component for the item.",
-          "$ref": "#definitions/rich-text-string"
-        },
-        "sub-sub": {
-          "title": "Sub-Sub Title",
-          "description": "The secondary subtitle component for the item. This is rarely used in practice, but see https://style.mla.org/punctuation-with-titles/.",
-          "$ref": "#definitions/rich-text-string"
-        },
         "alternate": {
           "title": "Alternate Title",
           "description": "An alternative variant title. This is rarely used in practice, but see https://style.mla.org/punctuation-with-titles/.",
@@ -70,6 +60,14 @@
           "title": "Short Title",
           "description": "A short variant title component for the item.",
           "$ref": "#definitions/rich-text-string"
+        },
+        "sub": {
+          "title": "Sub-Titles",
+          "description": "The sub-title components for the item, as an array. Typically, when there is a subtitle, there will only be one, but there are cases when there are more.",
+          "type": "array",
+          "items": {
+            "$ref": "#definitions/rich-text-string"
+          }
         }
       }
     },

--- a/schemas/input/csl-data.json
+++ b/schemas/input/csl-data.json
@@ -51,11 +51,6 @@
           "description": "The primary title component for the item.",
           "$ref": "#definitions/rich-text-string"
         },
-        "alternate": {
-          "title": "Alternate Title",
-          "description": "An alternative variant title. This is rarely used in practice, but see https://style.mla.org/punctuation-with-titles/.",
-          "$ref": "#definitions/rich-text-string"
-        },
         "short": {
           "title": "Short Title",
           "description": "A short variant title component for the item.",

--- a/schemas/input/csl-data.json
+++ b/schemas/input/csl-data.json
@@ -33,7 +33,7 @@
         },
         {
           "main": "England’s Monitor",
-          "alt": "The History of the Separation"
+          "alternate": "The History of the Separation"
         },
         {
           "main": "Kriegstagebuch des Oberkommandos der Wehrmacht, 1940–1945",

--- a/schemas/input/csl-data.json
+++ b/schemas/input/csl-data.json
@@ -1,4 +1,5 @@
 {
+  "title": "CSL JSON/YAML",
   "description": "JSON schema for CSL input data",
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "https://resource.citationstyles.org/schema/latest/input/json/csl-data.json",
@@ -7,6 +8,71 @@
     "$ref": "#/definitions/refitem"
   },
   "definitions": {
+    "title-variable": {
+      "title": "Title variable",
+      "description": "Titles are represented as an object.",
+      "$ref": "#definitions/title-object"
+    },
+    "title-object": {
+      "title": "Title Object",
+      "type": "object",
+      "examples": [
+        {
+          "full": "Finis Coronat Opus: A Curious Reciprocity; Shelley’s “When the Lamp Is Shattered”",
+          "main": "Finis Coronat Opus",
+          "sub": "A Curious Reciprocity",
+          "sub-sub": "Shelley’s “When the Lamp Is Shattered”"
+        },
+        {
+          "main": "Whose Music?",
+          "sub": "A Sociology of Musical Language"
+        },
+        {
+          "main": "Pardon the Interruption",
+          "sub": "Goal Proximity, Perceived Spare Time, and Impatience"
+        },
+        {
+          "main": "England’s Monitor",
+          "alt": "The History of the Separation"
+        },
+        {
+          "main": "Kriegstagebuch des Oberkommandos der Wehrmacht, 1940–1945",
+          "short": "Kriegstagebuch"
+        }
+      ],
+      "properties": {
+        "full": {
+          "title": "Full Title",
+          "description": "The full title string for the item; should generally be redundant, as it's simply the main + the sub titles and/or alternate title.",
+          "$ref": "#definitions/rich-text-string"
+        },
+        "main": {
+          "title": "Main Title",
+          "description": "The primary title component for the item.",
+          "$ref": "#definitions/rich-text-string"
+        },
+        "sub": {
+          "title": "Sub-Title",
+          "description": "The sub-title component for the item.",
+          "$ref": "#definitions/rich-text-string"
+        },
+        "sub-sub": {
+          "title": "Sub-Sub Title",
+          "description": "The secondary subtitle component for the item. This is rarely used in practice, but see https://style.mla.org/punctuation-with-titles/.",
+          "$ref": "#definitions/rich-text-string"
+        },
+        "alternate": {
+          "title": "Alternate Title",
+          "description": "An alternative variant title. This is rarely used in practice, but see https://style.mla.org/punctuation-with-titles/.",
+          "$ref": "#definitions/rich-text-string"
+        },
+        "short": {
+          "title": "Short Title",
+          "description": "A short variant title component for the item.",
+          "$ref": "#definitions/rich-text-string"
+        }
+      }
+    },
     "rich-text-string": {
       "title": "Rich Text String",
       "description": "A string that may include sub-string formatting for bold, italic, subscript, superscript, math, etc. The accompanying `csl-rich-text.yaml` schema defines experimental support for this in CSL JSON input.",
@@ -446,13 +512,10 @@
           "type": ["string", "number"]
         },
         "collection-title": {
-          "type": "string"
+          "$ref": "#definitions/title-variable"
         },
         "container-title": {
-          "type": "string"
-        },
-        "container-title-short": {
-          "type": "string"
+          "$ref": "#definitions/title-variable"
         },
         "dimensions": {
           "type": "string"
@@ -540,7 +603,7 @@
         },
         "original-title": {
           "description": "[Deprecated - Use `original` related `title` property instead]",
-          "type": "string"
+          "$ref": "#definitions/title-variable"
         },
         "page": {
           "type": ["string", "number"]
@@ -596,16 +659,10 @@
           "type": ["string", "number"]
         },
         "title": {
-          "type": "string"
-        },
-        "title-short": {
-          "type": "string"
+          "$ref": "#definitions/title-variable"
         },
         "translated-title": {
-          "type": "string"
-        },
-        "translated-title-short": {
-          "type": "string"
+          "$ref": "#definitions/title-variable"
         },
         "URL": {
           "type": "string"


### PR DESCRIPTION
## Description

As an alternative to title parsing to support independent formatting of main and subtitles, this converts title strings to objects, with the following properties:

- full
- main
- sub (an array, to support multiple)
- ~sub-sub~
- ~alternate~
- short

I added embedded examples to the schema, drawn directly from style guides (MLA and Chicago), and [here's](https://bdarcus.github.io/schema/csl-data.html#items_collection-title) example docs generated from the schema.

addresses #310.

## Alternatives

Alternatives I considered but rejected (though I don't feel strongly against them) using arrays for parts.

``` yaml
--- 
title-alt-1: 
  # change main parts to an array (Denis suggested this possibility)
  content: 
    - Main
    - Subtitle
    - "Second Subtitle"
  short: Main
title-alt-2: 
  # also change alt to an array
  content: 
    - Main
    - Subtitle
    - "Second Subtitle"
  short: Main
```

But, after subsequent discussion below, `sub` is now an array.

## See Also

https://discourse.citationstyles.org/t/design-principles-for-csl-json/1671

## Type of change

- [X] Variable addition (adds a new variable or type string)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] This change requires a documentation update
