### PR TITLE
input: Convert locator to an object array

### DIFF
--- a/schemas/input/csl-citation.json
+++ b/schemas/input/csl-citation.json
@@ -1,110 +1,152 @@
 {
-    "description": "JSON schema for CSL citation objects",
-    "$schema" : "http://json-schema.org/draft-07/schema#",
-    "$id": "https://resource.citationstyles.org/schema/latest/input/json/csl-citation.json",
-    "type": "object",
-    "properties": {
-        "schema": {
-            "type": "string",
-            "enum" : [
-                "https://resource.citationstyles.org/schema/latest/input/json/csl-citation.json" 
-            ] 
-        },
-        "citationID": {
-            "type": [
-                "string",
-                "number" 
-            ]
-        },
-        "citationItems": {
+  "description": "JSON schema for CSL citation objects",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://resource.citationstyles.org/schema/latest/input/json/csl-citation.json",
+  "type": "object",
+  "properties": {
+    "schema": {
+      "type": "string",
+      "enum": [
+        "https://resource.citationstyles.org/schema/latest/input/json/csl-citation.json"
+      ]
+    },
+    "citationID": {
+      "type": ["string", "number"]
+    },
+    "citationItems": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": ["string", "number"]
+          },
+          "itemData": {
+            "$ref": "csl-data.json#/items"
+          },
+          "prefix": {
+            "type": "string"
+          },
+          "suffix": {
+            "type": "string"
+          },
+          "locators": {
             "type": "array",
             "items": {
-                "type": "object",
-                "properties": {
-                    "id": {
-                        "type": [
-                            "string",
-                            "number" 
-                        ]
-                    },
-                    "itemData": {
-                        "$ref": "csl-data.json#/items" 
-                    },
-                    "prefix": {
-                        "type": "string" 
-                    },
-                    "suffix": {
-                        "type": "string" 
-                    },
-                    "locator": {
-                        "type": "string" 
-                    },
-                    "label": {
-                        "type": "string",
-                        "enum": [
-                            "appendix",
-                            "article",
-                            "book",
-                            "canon",
-                            "chapter",
-                            "column",
-                            "elocation",
-                            "equation",
-                            "figure",
-                            "folio",
-                            "issue",
-                            "line",
-                            "note",
-                            "opus",
-                            "page",
-                            "paragraph",
-                            "part",
-                            "rule",
-                            "section",
-                            "sub verbo",
-                            "supplement",
-                            "table",
-                            "timestamp",
-                            "title",
-                            "verse",
-                            "volume" 
-                        ] 
-                    },
-                    "suppress-author": {
-                        "type": [
-                            "string",
-                            "number",
-                            "boolean" 
-                        ] 
-                    },
-                    "author-only": {
-                        "type": [
-                            "string",
-                            "number",
-                            "boolean" 
-                        ] 
-                    },
-                    "uris": {
-                        "type": "array",
-                        "items": {
-                            "type": "string" 
-                        } 
-                    } 
-                },
-                "required": ["id"],
-                "additionalProperties" : false 
-            } 
+              "$ref": "#/definitions/locators"
+            }
+          },
+          "suppress-author": {
+            "type": ["string", "number", "boolean"]
+          },
+          "author-only": {
+            "type": ["string", "number", "boolean"]
+          },
+          "uris": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
         },
-        "properties": {
-            "type": "object",
-            "properties": {
-                "noteIndex": {
-                    "type": "number" 
-                } 
-            },
-            "additionalProperties" : false 
-        } 
+        "required": ["id"],
+        "additionalProperties": false
+      }
     },
-    "required": ["schema", "citationID"],
-    "additionalProperties" : false 
+    "properties": {
+      "type": "object",
+      "properties": {
+        "noteIndex": {
+          "type": "number"
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  "required": ["schema", "citationID"],
+  "additionalProperties": false,
+  "definitions": {
+    "locators": {
+      "properties": {
+        "appendix": {
+          "type": "string"
+        },
+        "article": {
+          "type": "string"
+        },
+        "book": {
+          "type": "string"
+        },
+        "canon": {
+          "type": "string"
+        },
+        "chapter": {
+          "type": "string"
+        },
+        "column": {
+          "type": "string"
+        },
+        "elocation": {
+          "type": "string"
+        },
+        "equation": {
+          "type": "string"
+        },
+        "figure": {
+          "type": "string"
+        },
+        "folio": {
+          "type": "string"
+        },
+        "issue": {
+          "type": "string"
+        },
+        "line": {
+          "type": "string"
+        },
+        "note": {
+          "type": "string"
+        },
+        "opus": {
+          "type": "string"
+        },
+        "page": {
+          "type": "string"
+        },
+        "paragraph": {
+          "type": "string"
+        },
+        "part": {
+          "type": "string"
+        },
+        "rule": {
+          "type": "string"
+        },
+        "section": {
+          "type": "string"
+        },
+        "sub-verbo": {
+          "type": "string"
+        },
+        "supplement": {
+          "type": "string"
+        },
+        "table": {
+          "type": "string"
+        },
+        "timestamp": {
+          "type": "string"
+        },
+        "title": {
+          "type": "string"
+        },
+        "verse": {
+          "type": "string"
+        },
+        "volume": {
+          "type": "string"
+        }
+      }
+    }
+  }
 }

--- a/schemas/input/csl-citation.json
+++ b/schemas/input/csl-citation.json
@@ -10,6 +10,10 @@
         "https://resource.citationstyles.org/schema/latest/input/json/csl-citation.json"
       ]
     },
+    "version": {
+      "type": "string",
+      "pattern": "1.1"
+    },
     "citationID": {
       "type": ["string", "number"]
     },


### PR DESCRIPTION
## Description

CSL input needs to accommodate possibility of multiple locators. Rather than requiring processors to parse a single string, this adds the structures to properly represent these data.

Example, in YAML

``` yaml
locators: 
  - 
    page: 23
  - 
    line: 12
```

This was easy enough to throw together, so I thought I'd post it for comment.

I also added a version property while I was at it.

Do you see any problem with doing this @fbennett?

## Type of change

- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] This change requires a documentation update
