### PR TITLE
Add repeatable attribute to rendering elements

### DIFF
--- a/schemas/styles/csl.rnc
+++ b/schemas/styles/csl.rnc
@@ -1012,6 +1012,13 @@ div {
 }
 # ==============================================================================
 
+## Allow repeated rendering of a rendering-element
+div {
+  ## By default, variables are rendered only once.
+  ## The "repeatable" attribute allows re-rendering of otherwise suppressed variables.
+  repeatable = attribute repeatable { xsd:boolean }?
+}
+
 ## Formatting attributes.
 div {
   affixes =

--- a/schemas/styles/csl.rnc
+++ b/schemas/styles/csl.rnc
@@ -1019,7 +1019,8 @@ div {
 div {
   ## By default, variables are rendered only once.
   ## The "repeatable" attribute allows re-rendering of otherwise suppressed variables.
-  repeatable = attribute repeatable { xsd:boolean }?
+  ## The "always-render" attribute allows re-rendering of otherwise suppressed variables.
+  always-render = attribute always-render { xsd:boolean }?
 }
 
 ## Formatting attributes.

--- a/schemas/styles/csl.rnc
+++ b/schemas/styles/csl.rnc
@@ -397,7 +397,7 @@ div {
     delimiter,
     display,
     font-formatting,
-    repeatable
+    always-render
   names.name =
     element cs:name {
       name.attributes,

--- a/schemas/styles/csl.rnc
+++ b/schemas/styles/csl.rnc
@@ -396,7 +396,8 @@ div {
     ## the same cs:names element.
     delimiter,
     display,
-    font-formatting
+    font-formatting,
+    repeatable
   names.name =
     element cs:name {
       name.attributes,
@@ -578,6 +579,7 @@ div {
       affixes,
       display,
       font-formatting,
+      repeatable,
       text-case
     }
   rendering-element.date.date-part.localized =
@@ -642,6 +644,7 @@ div {
       display,
       font-formatting,
       quotes,
+      repeatable,
       strip-periods,
       text-case
     }
@@ -673,7 +676,7 @@ div {
     
     ## Use to render a number variable.
     element cs:number {
-      number.attributes, affixes, display, font-formatting, text-case
+      number.attributes, affixes, display, font-formatting, repeatable, text-case
     }
   number.attributes =
     attribute variable { variables.numbers },

--- a/schemas/styles/csl.rnc
+++ b/schemas/styles/csl.rnc
@@ -676,7 +676,7 @@ div {
     
     ## Use to render a number variable.
     element cs:number {
-      number.attributes, affixes, display, font-formatting, repeatable, text-case
+      number.attributes, affixes, display, font-formatting, always-render, text-case
     }
   number.attributes =
     attribute variable { variables.numbers },

--- a/schemas/styles/csl.rnc
+++ b/schemas/styles/csl.rnc
@@ -579,7 +579,7 @@ div {
       affixes,
       display,
       font-formatting,
-      repeatable,
+      always-render,
       text-case
     }
   rendering-element.date.date-part.localized =

--- a/schemas/styles/csl.rnc
+++ b/schemas/styles/csl.rnc
@@ -644,7 +644,7 @@ div {
       display,
       font-formatting,
       quotes,
-      repeatable,
+      always-render,
       strip-periods,
       text-case
     }


### PR DESCRIPTION
## Description

In this [discussion](https://discourse.citationstyles.org/t/dropping-cs-substitute/697/52) on discourse, we somehow agreed on introducing general one time rendering, and a forced re-rendering with an attribute `repeatable=true`.

If we indeed introduce this, this will need an addition to the specs and a new attribute for rendering elements.

This PR already adds the required attribute for re-rendering otherwise suppressed variables.

Fixes #287 

## Type of change

- [X] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] This change requires a documentation update

## Checklist

- [X] I have installed the repo [pre-commit hook](https://github.com/citation-style-language/schema/blob/master/CONTRIBUTING.md#pre-commit-hooks); if not, and I have modified any of the schema files, I have run trang and/or prettier on the files, per [CONTRIBUTING](https://github.com/citation-style-language/schema/blob/master/CONTRIBUTING.md)
- [X] I have performed a self-review of my own code
