### PR TITLE
Add type and creator variables for grants/projects

### DIFF
--- a/schemas/input/csl-data.json
+++ b/schemas/input/csl-data.json
@@ -289,6 +289,7 @@
             "personal_communication",
             "post",
             "post-weblog",
+            "project",
             "regulation",
             "report",
             "review",
@@ -327,6 +328,12 @@
           }
         },
         "chair": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/name-variable"
+          }
+        },
+        "co-investigator": {
           "type": "array",
           "items": {
             "$ref": "#/definitions/name-variable"
@@ -418,6 +425,12 @@
           }
         },
         "performer": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/name-variable"
+          }
+        },
+        "principal-investigator": {
           "type": "array",
           "items": {
             "$ref": "#/definitions/name-variable"

--- a/schemas/styles/csl-types.rnc
+++ b/schemas/styles/csl-types.rnc
@@ -37,6 +37,7 @@ div {
     | "personal_communication"
     | "post"
     | "post-weblog"
+    | "project"
     | "regulation"
     | "report"
     | "review"

--- a/schemas/styles/csl-variables.rnc
+++ b/schemas/styles/csl-variables.rnc
@@ -25,6 +25,7 @@ div {
   variables.names =
     "author"
     | "chair"
+    | "co-investigator"
     | "collection-editor"
     | "compiler"
     | "composer"
@@ -41,6 +42,7 @@ div {
     | "organizer"
     | "original-author"
     | "performer"
+    | "principal-investigator"
     | "producer"
     | "recipient"
     | "reviewed-author"


### PR DESCRIPTION
Closes https://github.com/citation-style-language/schema/issues/293

## Description

Add a `project` type for grants and similar. For example, such items are often cited on CVs and grant applications.

@bdarcus You said in the linked thread "supporting grants would require more than just a type and creator variable". What else were you thinking? I think the other existing variables (publisher, genre, number, status) covers things.

## Type of change

- [X] Variable addition (adds a new variable or type string)