### PR TITLE
Add citation-label-format syntax

### DIFF
--- a/schemas/styles/csl-choose.rnc
+++ b/schemas/styles/csl-choose.rnc
@@ -40,7 +40,7 @@ div {
     | 
       ## Tests whether the locator matches the given locator types.
       attribute locator {
-        list { (terms.locator)+ }
+        list { terms.locator+ }
       }
     | 
       ## Tests whether the cite position matches the given positions.

--- a/schemas/styles/csl-citation-label-format.rnc
+++ b/schemas/styles/csl-citation-label-format.rnc
@@ -14,9 +14,11 @@ div {
        attribute label-style {
          
          ## Style used in citeproc-js for CLS 1.0.* styles
+         ## Wier16, WiPe16, WiPP16, WPPU16
          "citeproc"
          | 
            ## Default style used in biblatex
+           ## Wie16, WP16, WPP16, WPPU16
            "biblatex-default"
        }
        | 
@@ -39,6 +41,7 @@ div {
     
     ## Abbreviate non-date variables by extracting the first N characters.
     ## For list variables (e.g. names), extract chacters from each element.
+    ## If empty, variables are rendered without abbreviation.
     attribute width { xsd:integer }?,
     
     ## As "width", but for variables that are length 1 (e.g. single authors).

--- a/schemas/styles/csl-citation-label-format.rnc
+++ b/schemas/styles/csl-citation-label-format.rnc
@@ -1,0 +1,101 @@
+namespace a = "http://relaxng.org/ns/compatibility/annotations/1.0"
+namespace cs = "http://purl.org/net/xbiblio/csl"
+
+
+## cs:citation-label-format - Format for automatically generated citation-label
+div {
+  style.citation-label-format =
+    
+    ## Specify the format for automatically-generated citation-labels.
+    ## If unspecified, citation-labels are not automatically generated.
+    element cs:citation-label-format {
+      (
+       ## Specify a predefined label style
+       attribute label-style {
+         
+         ## Style used in citeproc-js for CLS 1.0.* styles
+         "citeproc"
+         | 
+           ## Default style used in biblatex
+           "biblatex-default"
+       }
+       | 
+         ## Specify a custom label style
+         (rendering-element+, citation-label.options)),
+      affixes,
+      [ a:defaultValue = "" ] delimiter,
+      font-formatting
+    }
+  
+  ## Citation Label Options
+  citation-label.options =
+    
+    ## Default values for inheritable attributes in citation-label-format
+    ## [ a:defaultValue = "" ] names-delimiter
+    ## [ a:defaultValue = "" ] name-delimiter
+    ## [ a:defaultValue = "short" ] name-form
+    names-inheritable-options,
+    name-inheritable-options,
+    
+    ## Abbreviate non-date variables by extracting the first N characters.
+    ## For list variables (e.g. names), extract chacters from each element.
+    attribute width { xsd:integer }?,
+    
+    ## As "width", but for variables that are length 1 (e.g. single authors).
+    attribute width-single { xsd:integer }?,
+    
+    ## Set to "true" to treat parts of names or strings separated by whitepace 
+    ## or hyphens as separate elements when abbreviating.
+    [ a:defaultValue = "false" ]
+    attribute split-compound { xsd:boolean }?,
+    
+    ## Set to an integer to force the non-date part of citation-label to be the 
+    ## specified length (e.g. to make all labels 4 characters long).
+    ## Set to "true" to force all non-date parts of a citation label to be the
+    ## same length as the longest disambiguated non-date citation label part.
+    [ a:defaultValue = "false" ]
+    attribute fixed-width { xsd:integer | xsd:boolean }?,
+    
+    ## Set to "true" to activate disambiguation by adding additional characters 
+    ## to abbreviated variables in label.
+    attribute disambiguate-add-characters { xsd:boolean }?,
+    
+    ## Specify how variables are expanded for disambiguation.
+    attribute characters-disambiguation-rule {
+      
+      ## Ambiguous abbreviations in the same position are expanded until 
+      ## disambiguated (when disambiguation is not possible, the name/text
+      ## remains in its original form).
+      "by-position"
+      | 
+        ## As "by-position", but only ambiguous names in ambiguous cites are
+        ## expanded.
+        "by-cite"
+    }?,
+    
+    ## Set the maximum number of characters to add when disambiguating.
+    attribute disambiguate-max-characters { xsd:integer }?,
+    
+    ## Set to "true" to activate disambiguation by adding year-suffixes
+    ## (e.g., "ABC18a, ABC18b") for ambiguous citation labels.
+    [ a:defaultValue = "false" ]
+    attribute disambiguate-add-year-suffix { xsd:boolean }?,
+    
+    ## The form of the cs:et-al term to use when et-al abbreviation is activated. 
+    ## Set to "none" to omit the term. Set to "long", "short", or "symbol" to
+    ## render the respective form of the term.
+    [ a:defaultValue = "none" ]
+    attribute et-al-form { "none" | "long" | "short" | "symbol" }?,
+    
+    ## If specified and fixed-width="true", if a non-date part of a
+    ## citation-label lacks sufficient characters, add the specified character 
+    ## to the end of the non-date part of the citation label until it is the
+    ## correct length
+    attribute pad-character { padchar }?,
+    
+    ## If specified and fixed-width="true", if a date part of a citation-label 
+    ## lacks sufficient characters, add the specified character to the end of 
+    ## the date part of the citation label until it is the correct length
+    attribute pad-character-date { padchar }?
+  padchar = xsd:string { pattern = "." }
+}

--- a/schemas/styles/csl-data.rnc
+++ b/schemas/styles/csl-data.rnc
@@ -1,14 +1,20 @@
+namespace a = "http://relaxng.org/ns/compatibility/annotations/1.0"
 namespace dc = "http://purl.org/dc/elements/1.1/"
 
 dc:title [ "Citation Style Language Data" ]
 dc:creator [ "Bruce D'Arcus" ]
-dc:rights [ "Copyright 2009-2018 Citation Style Language and contributors" ]
+dc:rights [
+  "Copyright 2009-2018 Citation Style Language and contributors"
+]
 dc:license [ "MIT license" ]
 dc:description [ "A schema for the CSL data model." ]
 include "csl-types.rnc"
 include "csl-variables.rnc"
 start = element references { reference+ }
-reference = element reference { type, id, uri?, container-uri?, (contributor* & date* & variable+) }
+reference =
+  element reference {
+    type, id, uri?, container-uri?, (contributor* & date* & variable+)
+  }
 
 ## Types 
 div {
@@ -17,88 +23,93 @@ div {
 
 ## Identifiers
 div {
-
-   ## The id is an identifier unique to the scope of the file
-   id = attribute id { token }
-   
-   ## The URI is the global identity for the refererence; used to associate a citation reference to its data
-   uri = attribute uri { xsd:anyURI }
   
-   ## the URI for containing items (such as edited books or journals)
-   container-uri = attribute container-uri { xsd:anyURI }
+  ## The id is an identifier unique to the scope of the file
+  id = attribute id { token }
+  
+  ## The URI is the global identity for the refererence; used to associate a citation reference to its data
+  uri = attribute uri { xsd:anyURI }
+  
+  ## the URI for containing items (such as edited books or journals)
+  container-uri = attribute container-uri { xsd:anyURI }
 }
 
 ## Contributors
 div {
-   contributor =
-      element contributor {
-         attribute type { variables.names },
-         name-elements
-      }
-   name-elements =
-      element name { text }
-    | ((element given { text }? &
-       element family { text }?) &
-       element dropping-particle { text }? &
-       element non-dropping-particle { text }? &
-       element suffix { text }?)
+  contributor =
+    element contributor {
+      attribute type { variables.names },
+      name-elements
+    }
+  name-elements =
+    element name { text }
+    | ((element given { text }?
+        & element family { text }?)
+       & element dropping-particle { text }?
+       & element non-dropping-particle { text }?
+       & element suffix { text }?)
 }
 
 ## Dates
 div {
-   date =
-      element date { 
-         attribute type { variables.dates }, 
-         attribute circa { xsd:boolean }?,
-         (date-pattern | date-range)
-      }
-   date-pattern =
-      year-pattern,
-      ( ( month-pattern, day-pattern? ) | season-pattern )?
-   date-range =
-      element begin-date { date-pattern },
-      element end-date { date-pattern }?
-   year-pattern =
-      attribute year {
-         xsd:integer { maxInclusive="-1" }
-       | xsd:integer { minInclusive="1" }
-      }
-   month-pattern =
-      attribute month { xsd:integer { minInclusive="1" maxInclusive="12" } }
-   day-pattern =
-      attribute day { xsd:integer { minInclusive="1" maxInclusive="31" } }
-
-   # 1 = Spring, 2 = Summer, 3 = Fall, 4 = Winter
-   season-pattern =
-      attribute season { xsd:integer { minInclusive="1" maxInclusive="4" } }
+  date =
+    element date {
+      attribute type { variables.dates },
+      attribute circa { xsd:boolean }?,
+      (date-pattern | date-range)
+    }
+  date-pattern =
+    year-pattern,
+    ((month-pattern, day-pattern?) | season-pattern)?
+  date-range =
+    element begin-date { date-pattern },
+    element end-date { date-pattern }?
+  year-pattern =
+    attribute year {
+      xsd:integer { maxInclusive = "-1" }
+      | xsd:integer { minInclusive = "1" }
+    }
+  month-pattern =
+    attribute month {
+      xsd:integer { minInclusive = "1" maxInclusive = "12" }
+    }
+  day-pattern =
+    attribute day {
+      xsd:integer { minInclusive = "1" maxInclusive = "31" }
+    }
+  # 1 = Spring, 2 = Summer, 3 = Fall, 4 = Winter
+  season-pattern =
+    attribute season {
+      xsd:integer { minInclusive = "1" maxInclusive = "4" }
+    }
 }
 
 ## Simple Variables
 div {
-   variable =
-      element variable {
-         attribute type { variables.standard },
-         (simple-variable-pattern | rich-variable-pattern)
-      }
-   simple-variable-pattern = text
-   rich-variable-pattern =
-      (text
-       | element abbr { text }
-       | element b { text }
-       | element cite {
-          
-          ## cited title which is a part (like an article), and so typically rendered in quotes, rather than italicized
-          attribute class { "part" }?,
-          text
+  variable =
+    element variable {
+      attribute type { variables.standard },
+      (simple-variable-pattern | rich-variable-pattern)
+    }
+  simple-variable-pattern = text
+  rich-variable-pattern =
+    (text
+     | element abbr { text }
+     | element b { text }
+     | element cite {
+         
+         ## cited title which is a part (like an article), and so typically rendered in quotes, rather than italicized
+         attribute class { "part" }?,
+         text
        }
-       | element i { text }
-       | element sc { text }
-       | element span {
-          
-          ## text whose case should not be transformed (as with proper nouns)
-          attribute class { "protect" }?,
-          text
+     | element i { text }
+     | element sc { text }
+     | element span {
+         
+         ## text whose case should not be transformed (as with proper nouns)
+         attribute class { "protect" }?,
+         text
        }
-       | element sup { text }
-       | element sub { text })+
+     | element sup { text }
+     | element sub { text })+
 }

--- a/schemas/styles/csl-relaxed.rnc
+++ b/schemas/styles/csl-relaxed.rnc
@@ -5,9 +5,8 @@ dc:title [ "Citation Style Language Schema - Relaxed" ]
 dc:creator [ "Bruce D'Arcus" ]
 dc:rights [ "Permission to freely use, copy and distribute." ]
 dc:description [
-    "Relaxes the need for a cs:updated value in the official CSL schema."
+  "Relaxes the need for a cs:updated value in the official CSL schema."
 ]
-
-include "csl.rnc"{
-   info-updated = element cs:updated { xsd:dateTime? }
+include "csl.rnc" {
+  info-updated = element cs:updated { xsd:dateTime? }
 }

--- a/schemas/styles/csl-repository.rnc
+++ b/schemas/styles/csl-repository.rnc
@@ -2,24 +2,25 @@ namespace a = "http://relaxng.org/ns/compatibility/annotations/1.0"
 namespace cs = "http://purl.org/net/xbiblio/csl"
 namespace dc = "http://purl.org/dc/elements/1.1/"
 
-dc:title [ "Extension schema for the Citation Style Language styles repository" ]
+dc:title [
+  "Extension schema for the Citation Style Language styles repository"
+]
 dc:creator [ "Rintze M. Zelle" ]
-dc:rights [ "Copyright 2013-2018 Citation Style Language and contributors" ]
+dc:rights [
+  "Copyright 2013-2018 Citation Style Language and contributors"
+]
 dc:license [ "MIT license" ]
 dc:description [
   "Enforces stricter requirements for the styles in the official CSL styles repository."
 ]
-
 include "csl.rnc" {
-
+  
   ## Remove legacy attributes from cs:style of dependents
   dependent-style.style =
     element cs:style {
-      style.default-locale,
-      version,
-      dependent-style.style.info
+      style.default-locale, version, dependent-style.style.info
     }
-
+  
   ## - Only allow cs:issn once
   ## - Require a cs:rights element
   ## - Forgo "interleave" (so the elements need to be in the order specified),
@@ -50,7 +51,7 @@ include "csl.rnc" {
       info.updated,
       info.rights
     }
-    
+  
   ## - Only allow cs:issn once
   ## - Require a cs:rights element
   ## - Forgo "interleave" (so the elements need to be in the order specified),
@@ -81,16 +82,18 @@ include "csl.rnc" {
       info.updated,
       info.rights
     }
-
+  
   ## Require "license" attribute; require specific value for "license" attribute and
   ## text content for cs:rights
   info.rights =
     element cs:rights {
-      attribute license { "http://creativecommons.org/licenses/by-sa/3.0/" },
+      attribute license {
+        "http://creativecommons.org/licenses/by-sa/3.0/"
+      },
       attribute xml:lang { xsd:language }?,
       "This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License"
     }
-
+  
   ## Remove legacy attributes from cs:et-al
   names.et-al =
     
@@ -103,41 +106,35 @@ include "csl.rnc" {
       font-formatting
     }
 }
-
 independent-style.info.link.self =
-element cs:link {
-  attribute href { xsd:anyURI },
-  attribute rel { "self" },
-  info-text
-}
-
+  element cs:link {
+    attribute href { xsd:anyURI },
+    attribute rel { "self" },
+    info-text
+  }
 independent-style.info.link.template =
-element cs:link {
-  attribute href { xsd:anyURI },
-  attribute rel { "template" },
-  info-text
-}
-
+  element cs:link {
+    attribute href { xsd:anyURI },
+    attribute rel { "template" },
+    info-text
+  }
 independent-style.info.link.independent-parent =
-element cs:link {
-  attribute href { xsd:anyURI },
-  attribute rel { "independent-parent" },
-  info-text
-}
-
+  element cs:link {
+    attribute href { xsd:anyURI },
+    attribute rel { "independent-parent" },
+    info-text
+  }
 independent-style.info.link.documentation =
-element cs:link {
-  attribute href { xsd:anyURI },
-  attribute rel { "documentation" },
-  info-text
-}
-
+  element cs:link {
+    attribute href { xsd:anyURI },
+    attribute rel { "documentation" },
+    info-text
+  }
 info.category.citation-format =
-element cs:category {
-  attribute citation-format { category.citation-format }
-}
-
+  element cs:category {
+    attribute citation-format { category.citation-format }
+  }
 info.category.field =
-element cs:category {
-  attribute field { category.field }
-}
+  element cs:category {
+    attribute field { category.field }
+  }

--- a/schemas/styles/csl-variables.rnc
+++ b/schemas/styles/csl-variables.rnc
@@ -3,14 +3,14 @@ namespace a = "http://relaxng.org/ns/compatibility/annotations/1.0"
 
 ## Variables
 div {
-
+  
   ## All variables
   variables = variables.dates | variables.names | variables.standard
-
+  
   ## Standard variables
   variables.standard =
     variables.numbers | variables.strings | variables.titles
-
+  
   ## Date variables
   variables.dates =
     "accessed"
@@ -20,7 +20,7 @@ div {
     | "issued"
     | "original-date"
     | "submitted"
-
+  
   ## Name variables
   variables.names =
     "author"
@@ -45,7 +45,7 @@ div {
     | "recipient"
     | "reviewed-author"
     | "translator"
-
+  
   ## Number variables
   variables.numbers =
     "chapter-number"
@@ -64,7 +64,7 @@ div {
     | "printing"
     | "supplement"
     | "volume"
-
+  
   ## Title variables
   variables.titles =
     "collection-title"
@@ -75,7 +75,7 @@ div {
     | "title"
     | "translated-title"
     | "volume-title"
-
+  
   ## String variables
   variables.strings =
     "abstract"

--- a/schemas/styles/csl.rnc
+++ b/schemas/styles/csl.rnc
@@ -22,6 +22,7 @@ dc:description [
 
 ## Subparts of the CSL schema
 include "csl-choose.rnc"
+include "csl-citation-label-format.rnc"
 include "csl-terms.rnc"
 include "csl-types.rnc"
 include "csl-variables.rnc"
@@ -45,7 +46,8 @@ div {
        & style.macro*
        & style.citation
        & style.intext?
-       & style.bibliography?)
+       & style.bibliography?
+       & style.citation-label-format?)
     }
   dependent-style.style =
     element cs:style {
@@ -232,7 +234,7 @@ div {
     element cs:style-options {
       
       ## Select the localized era notation format ("ce" or "ad")
-      attribute era-notation {"ce" | "ad"}?,
+      attribute era-notation { "ce" | "ad" }?,
       
       ## Specify the space character to be used between initialized first names and family names, 
       ## e.g. a non-breaking space.
@@ -282,8 +284,10 @@ div {
       affixes,
       font-formatting,
       text-case,
-      attribute term { list { date.era-terms+ }} 
-    } 
+      attribute term {
+        list { date.era-terms+ }
+      }
+    }
   locale.date.date-part =
     element cs:date-part {
       affixes, font-formatting, text-case, (day | month | year)
@@ -687,7 +691,12 @@ div {
     
     ## Use to render a number variable.
     element cs:number {
-      number.attributes, affixes, display, font-formatting, always-render, text-case
+      number.attributes,
+      affixes,
+      display,
+      font-formatting,
+      always-render,
+      text-case
     }
   number.attributes =
     attribute variable { variables.numbers },
@@ -975,13 +984,15 @@ div {
         "full"
     }?
   
-  ## Options affecting cs:names, for cs:style, cs:citation and cs:bibliography.
+  ## Options affecting cs:names, for cs:style, cs:citation, cs:bibliography,
+  ## and cs:citation-label.
   names-inheritable-options =
     
     ## Inheritable name option, companion for "delimiter" on cs:names.
     attribute names-delimiter { text }?
   
-  ## Options affecting cs:name, for cs:style, cs:citation and cs:bibliography.
+  ## Options affecting cs:name, for cs:style, cs:citation, cs:bibliography,
+  ## and cs:citation-label.
   name-inheritable-options =
     name.attributes,
     
@@ -1028,6 +1039,7 @@ div {
 
 ## Allow repeated rendering of a rendering-element
 div {
+  
   ## By default, variables are rendered only once.
   ## The "repeatable" attribute allows re-rendering of otherwise suppressed variables.
   ## The "always-render" attribute allows re-rendering of otherwise suppressed variables.


### PR DESCRIPTION
## Description

Add syntax for specifying citation label format. Based on the biblatex label syntax: http://mirrors.ibiblio.org/CTAN/macros/latex/contrib/biblatex/doc/biblatex.pdf

It adds a `cs:citation-label-format` element.

It can take either `label-type` attribute to specify one of two prespecified formats or a combination of options attributes and rendering elements to generate a custom format.

Fixes https://github.com/citation-style-language/schema/issues/295

## Type of change

- [X] New feature (non-breaking change which adds functionality)
- [X] This change requires a documentation update
