### PR TITLE
Rename initial-family-name-delimiter

### DIFF
--- a/schemas/styles/csl.rnc
+++ b/schemas/styles/csl.rnc
@@ -236,10 +236,11 @@ div {
       ## Select the localized era notation format ("ce" or "ad")
       attribute era-notation { "ce" | "ad" }?,
       
-      ## Specify the space character to be used between initialized first names and family names, 
+      ## Specify the space character to be used between "small" name parts
+      ## i.e., between initialized given names or particles and other name parts
       ## e.g. a non-breaking space.
       [ a:defaultValue = " " ]
-      attribute initial-family-name-delimiter { text }?,
+      attribute small-name-part-delimiter { text }?,
       
       ## Limit the "ordinal" form to the first day of the month.
       [ a:defaultValue = "false" ]


### PR DESCRIPTION
Looking at the name rendering code in citeproc-js [here](https://github.com/Juris-M/citeproc-js/blob/e2415f8257a9f9c71ebacbe700076a88307a8c97/src/util_names_render.js#L559), I notice that the localized non-breaking space is also used to join particles in the name, so I suggest we rename and expand the scope of this attribute slightly.

One thing that's not clear to me is that this localized no-break space is only used (1) when names are not displayed in sort order and (2) if initalize-with contains a no-break space (see [here](https://github.com/Juris-M/citeproc-js/blob/e2415f8257a9f9c71ebacbe700076a88307a8c97/src/util_names_render.js#L472) and [here](https://github.com/Juris-M/citeproc-js/blob/9111953a18ec32ca4f6b2d8a3738c2c8b0ca9e37/CHANGES-1.1.txt#L1415)).

@fbennett Can you comment on that? What is the logic behind only using the non-breaking space if displayed in non-sort-order?

## Type of change

- [X] New feature (non-breaking change which adds functionality)
