### PR TITLE
Add `volume-editor` and `volume-translator`

### DIFF
--- a/schemas/input/csl-data.json
+++ b/schemas/input/csl-data.json
@@ -382,6 +382,12 @@
             "$ref": "#/definitions/name-variable"
           }
         },
+        "container-translator": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/name-variable"
+          }
+        },
         "contributor": {
           "type": "array",
           "items": {
@@ -475,6 +481,18 @@
           }
         },
         "translator": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/name-variable"
+          }
+        },
+        "volume-editor": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/name-variable"
+          }
+        },
+        "volume-translator": {
           "type": "array",
           "items": {
             "$ref": "#/definitions/name-variable"

--- a/schemas/input/csl-data.json
+++ b/schemas/input/csl-data.json
@@ -382,12 +382,6 @@
             "$ref": "#/definitions/name-variable"
           }
         },
-        "container-translator": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/name-variable"
-          }
-        },
         "contributor": {
           "type": "array",
           "items": {

--- a/schemas/input/csl-data.json
+++ b/schemas/input/csl-data.json
@@ -382,6 +382,12 @@
             "$ref": "#/definitions/name-variable"
           }
         },
+        "container-translator": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/name-variable"
+          }
+        },
         "contributor": {
           "type": "array",
           "items": {

--- a/schemas/styles/csl-variables.rnc
+++ b/schemas/styles/csl-variables.rnc
@@ -30,6 +30,7 @@ div {
     | "compiler"
     | "composer"
     | "container-author"
+    | "container-translator"
     | "contributor"
     | "curator"
     | "director"

--- a/schemas/styles/csl-variables.rnc
+++ b/schemas/styles/csl-variables.rnc
@@ -30,7 +30,6 @@ div {
     | "compiler"
     | "composer"
     | "container-author"
-    | "container-translator"
     | "contributor"
     | "curator"
     | "director"

--- a/schemas/styles/csl-variables.rnc
+++ b/schemas/styles/csl-variables.rnc
@@ -30,6 +30,7 @@ div {
     | "compiler"
     | "composer"
     | "container-author"
+    | "container-translator"
     | "contributor"
     | "curator"
     | "director"
@@ -47,6 +48,8 @@ div {
     | "recipient"
     | "reviewed-author"
     | "translator"
+    | "volume-editor"
+    | "volume-translator"
   
   ## Number variables
   variables.numbers =


### PR DESCRIPTION
## Description

Some role variables (e.g. `editor` and `translator`) can relate to title variables on multiple levels: `title`, `container-title`, `volume-title`, `collection-title`, i.e., multi-volume publications can have editors for the whole publication, and also editors for specific volumes. 

Currently, we have only one translator variable, and two editor variables: `editor` and `collection-editor`, so we're not able to deal with this complexity properly.

This PR adds new role variables: `volume-editor`, and `volume-translator`, `container-translator`.

This should be RTM.

Partially closes #289 

## Open Question:

Should this also deal with the "editor@title vs. editor@container-title" case? Currently, styles use conditionals à la `if type="chapter ..."` to deal with this.

## Type of change

Please delete options that are not relevant.

- [X] Variable addition (adds a new variable or type string)
- [] This change requires a documentation update

## Checklist

- [X] I have installed the repo [pre-commit hook](https://github.com/citation-style-language/schema/blob/master/CONTRIBUTING.md#pre-commit-hooks); if not, and I have modified any of the schema files, I have run trang and/or prettier on the files, per [CONTRIBUTING](https://github.com/citation-style-language/schema/blob/master/CONTRIBUTING.md)
- [X] I have performed a self-review of my own code
- [] I have included suggested corresponding changes to the documentation (if relevant)
