### PR TITLE
Add `label` attribute to names schema

### DIFF
--- a/schemas/input/csl-data.json
+++ b/schemas/input/csl-data.json
@@ -256,6 +256,10 @@
               "description": "E.g. rendered as 'Smith, J. [@JSmith]'",
               "type": "string"
             },
+            "label": {
+              "title": "Non-default label to use when rendering name",
+              "description": "Overrides the default label for the role. e.g. to indicate a subtype of a role or specific MARC or CRediT roles."
+            },
             "parse-names": {
               "type": "boolean"
             },


### PR DESCRIPTION
Used to override the default label rendered for a role.

Following the discussion at https://github.com/citation-style-language/schema/issues/293 and https://forums.zotero.org/discussion/84042/tromso-recommendations-for-citation-of-research-data-in-linguistics this lets a user enter a more specific role label without requiring such things to have their own variable types. For example, a linguist might cite the person whose speech they are studying as an `author` with `label: "speaker"`.

## Type of change

- [X] New feature (non-breaking change which adds functionality)
- [X] This change requires a documentation update
