### PR TITLE
input: Remove static-ordering and comma-suffix

### DIFF
--- a/schemas/input/csl-data.json
+++ b/schemas/input/csl-data.json
@@ -235,12 +235,6 @@
             "suffix": {
               "type": "string"
             },
-            "comma-suffix": {
-              "type": ["string", "number", "boolean"]
-            },
-            "static-ordering": {
-              "type": ["string", "number", "boolean"]
-            },
             "institution": {
               "title": "Literal name text; should not be parsed",
               "description": "Use for institutional creator names; e.g. 'National Institutes of Health'",


### PR DESCRIPTION
Per @fbennett, these are no longer needed for contributor names. 

See:

https://github.com/citation-style-language/documentation/pull/39#issuecomment-667672082
https://github.com/citation-style-language/documentation/pull/39#issuecomment-667757772
