### PR TITLE
remove translated-title

### DIFF
--- a/schemas/input/csl-data.json
+++ b/schemas/input/csl-data.json
@@ -423,12 +423,6 @@
       "title-short": {
         "type": "string"
       },
-      "translated-title": {
-        "type": "string"
-      },
-      "translated-title-short": {
-        "type": "string"
-      },
       "URL": {
         "type": "string"
       },

--- a/schemas/styles/csl-variables.rnc
+++ b/schemas/styles/csl-variables.rnc
@@ -79,7 +79,6 @@ div {
     | "part-title"
     | "reviewed-title"
     | "title"
-    | "translated-title"
     | "volume-title"
   
   ## String variables


### PR DESCRIPTION
## Description

If we indeed plan to add a `language-alternate` object to the title object, we should not add ` translated-title` in 1.0.2. So this PR removes this variables again.

- [X] Variable addition (adds a new variable or type string)
- [X] This change requires a documentation update

## Checklist

- [X] I have installed the repo [pre-commit hook](https://github.com/citation-style-language/schema/blob/master/CONTRIBUTING.md#pre-commit-hooks); if not, and I have modified any of the schema files, I have run trang and/or prettier on the files, per [CONTRIBUTING](https://github.com/citation-style-language/schema/blob/master/CONTRIBUTING.md)
- [X] I have performed a self-review of my own code
- [] I have included suggested corresponding changes to the documentation (if relevant)
