### PR TITLE
input: Add new citation command property

### DIFF
--- a/schemas/input/csl-citation.json
+++ b/schemas/input/csl-citation.json
@@ -43,7 +43,7 @@
           "command": {
             "type": "string",
             "title": "Special citation command",
-            "descriptions": "Calls for a non-default citation format",
+            "descriptions": "Specifies a non-default citation format; respectively 'Doe (2019)', '(2019)' and 'Doe'",
             "enum": ["narrative", "suppress-author", "author-only"]
           },
           "uris": {

--- a/schemas/input/csl-citation.json
+++ b/schemas/input/csl-citation.json
@@ -43,7 +43,6 @@
           "command": {
             "type": "string"
             "enum": ["author-in-text", "suppress-author", "author-only"]
-            ]
           },
           "uris": {
             "type": "array",

--- a/schemas/input/csl-citation.json
+++ b/schemas/input/csl-citation.json
@@ -42,7 +42,9 @@
           },
           "command": {
             "type": "string",
-            "enum": ["author-in-text", "suppress-author", "author-only"]
+            "title": "Special citation command",
+            "descriptions": "Calls for a non-default citation format",
+            "enum": ["narrative", "suppress-author", "author-only"]
           },
           "uris": {
             "type": "array",

--- a/schemas/input/csl-citation.json
+++ b/schemas/input/csl-citation.json
@@ -41,10 +41,10 @@
             }
           },
           "suppress-author": {
-            "type": ["string", "number", "boolean"]
+            "type": "boolean"
           },
           "author-only": {
-            "type": ["string", "number", "boolean"]
+            "type": "boolean"
           },
           "uris": {
             "type": "array",

--- a/schemas/input/csl-citation.json
+++ b/schemas/input/csl-citation.json
@@ -40,11 +40,10 @@
               "$ref": "#/definitions/locators"
             }
           },
-          "suppress-author": {
-            "type": "boolean"
-          },
-          "author-only": {
-            "type": "boolean"
+          "command": {
+            "type": "string"
+            "enum": ["author-in-text", "suppress-author", "author-only"]
+            ]
           },
           "uris": {
             "type": "array",

--- a/schemas/input/csl-citation.json
+++ b/schemas/input/csl-citation.json
@@ -41,7 +41,7 @@
             }
           },
           "command": {
-            "type": "string"
+            "type": "string",
             "enum": ["author-in-text", "suppress-author", "author-only"]
           },
           "uris": {


### PR DESCRIPTION
Removes the two boolean citation command flags, and replaces with a 
new "command" property, with possible values of "suppress-author" and 
"author-only".

Also adds a new "narrative" option to that list, to support textual or 
author-in-text citations like "Doe (2019)" that are now supported with 
the new intext style element.

Closes #214