### PR TITLE
Remove redundant short title properties from JSON schema

### DIFF
--- a/schemas/input/csl-data.json
+++ b/schemas/input/csl-data.json
@@ -327,12 +327,6 @@
         "language": {
           "type": "string"
         },
-        "journalAbbreviation": {
-          "type": "string"
-        },
-        "shortTitle": {
-          "type": "string"
-        },
         "author": {
           "type": "array",
           "items": {


### PR DESCRIPTION
## Description

These are now stored as the "short" property of each "title" variable.

Fixes https://github.com/citation-style-language/schema/issues/113#issuecomment-672834744

## Type of change

- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] This change requires a documentation update
