### PR TITLE
Make year suffix localizable

### DIFF
--- a/schemas/styles/csl.rnc
+++ b/schemas/styles/csl.rnc
@@ -253,7 +253,7 @@ div {
       ## Alphabet to use for generating year suffixes.
       [ a:defaultValue = "latin" ]
       attribute year-suffix-alphabet {
-        "latin" | "abjad" | "cyrillic" | "greek" | "hebrew" | "persian"
+        "latin" | "arabic" | "cyrillic" | "greek" | "hebrew" | "persian"
       }?
     }
   locale-file.locale =

--- a/schemas/styles/csl.rnc
+++ b/schemas/styles/csl.rnc
@@ -248,7 +248,13 @@ div {
       ## Specify whether punctuation (a period or comma) is placed within
       ## or outside (default) the closing quotation mark.
       [ a:defaultValue = "false" ]
-      attribute punctuation-in-quote { xsd:boolean }?
+      attribute punctuation-in-quote { xsd:boolean }?,
+      
+      ## Alphabet to use for generating year suffixes.
+      [ a:defaultValue = "latin" ]
+      attribute year-suffix-alphabet {
+        "latin" | "abjad" | "cyrillic" | "greek" | "hebrew" | "persian"
+      }?
     }
   locale-file.locale =
     element cs:locale {


### PR DESCRIPTION
Allows locales to specify the alphabet set to use for year-suffixes.

Fixes https://github.com/citation-style-language/schema/issues/136