### PR TITLE
Remove deprecated event variable

### DIFF
--- a/schemas/styles/csl-variables.rnc
+++ b/schemas/styles/csl-variables.rnc
@@ -98,8 +98,6 @@ div {
     | "dimensions"
     | "division"
     | "DOI"
-    | # Alias for 'event-title'. Deprecated. Will be removed in CSL 1.1.
-      "event"
     | "event-title"
     | "event-place"
     | "genre"


### PR DESCRIPTION
## Description

The variable `event` is marked as deprecated already. Should be removed in 1.1.

## Type of change

Please delete options that are not relevant.

- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] This change requires a documentation update

## Checklist

- [X] I have installed the repo [pre-commit hook](https://github.com/citation-style-language/schema/blob/master/CONTRIBUTING.md#pre-commit-hooks); if not, and I have modified any of the schema files, I have run trang and/or prettier on the files, per [CONTRIBUTING](https://github.com/citation-style-language/schema/blob/master/CONTRIBUTING.md)
- [X] I have performed a self-review of my own code
- [] I have included suggested corresponding changes to the documentation (if relevant)
