### PR TITLE
remove term

### DIFF
--- a/schemas/styles/csl-terms.rnc
+++ b/schemas/styles/csl-terms.rnc
@@ -11,7 +11,6 @@ div {
     | 
       ## Contributor roles
       variables.names
-    | "editortranslator"
     | 
       ## Miscellaneous terms
       "accessed"


### PR DESCRIPTION
## Description
The introduction of `editor-translator` as a testable name variable makes the `editortranslator` term redundant.

## Type of change

Please delete options that are not relevant.

- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] This change requires a documentation update

## Checklist

- [X] I have installed the repo [pre-commit hook](https://github.com/citation-style-language/schema/blob/master/CONTRIBUTING.md#pre-commit-hooks); if not, and I have modified any of the schema files, I have run trang and/or prettier on the files, per [CONTRIBUTING](https://github.com/citation-style-language/schema/blob/master/CONTRIBUTING.md)
- [X] I have performed a self-review of my own code
- [] I have included suggested corresponding changes to the documentation (if relevant)
