### PR TITLE
Add string locator type

### DIFF
--- a/schemas/input/csl-citation.json
+++ b/schemas/input/csl-citation.json
@@ -248,6 +248,11 @@
           }
         },
         {
+          "string": {
+            "$ref": "#/definitions/locator-variable"
+          }
+        },
+        {
           "sub-verbo": {
             "$ref": "#/definitions/locator-variable"
           }

--- a/schemas/input/csl-citation.json
+++ b/schemas/input/csl-citation.json
@@ -145,6 +145,9 @@
     "locator": {
       "anyOf": [
         {
+          "type": "string"
+        },
+        {
           "$ref": "#/definitions/locator-range"
         },
         {
@@ -244,11 +247,6 @@
         },
         {
           "section": {
-            "$ref": "#/definitions/locator-variable"
-          }
-        },
-        {
-          "string": {
             "$ref": "#/definitions/locator-variable"
           }
         },


### PR DESCRIPTION
For custom special locator types (e.g., "Psalms 4:3–6"). No label is applied to string. After realizing that pandoc has a way to distinguish these from suffixes (https://github.com/citation-style-language/schema/issues/94#issuecomment-651167640), I don't see a problem with this existing.

Closes https://github.com/citation-style-language/schema/issues/94