### PR TITLE
Remove title split

### DIFF
--- a/schemas/styles/csl.rnc
+++ b/schemas/styles/csl.rnc
@@ -1052,7 +1052,7 @@ div {
     [ a:defaultValue = "simple" ]
     attribute normalize-title-delimiters {
       
-      ## Normalize "."", ":", "::"
+      ## Normalize ".", ":", "::"
       "simple"
       | 
         ## Normalize the values for "simple" plus ";"

--- a/schemas/styles/csl.rnc
+++ b/schemas/styles/csl.rnc
@@ -1052,7 +1052,7 @@ div {
     [ a:defaultValue = "simple" ]
     attribute normalize-title-delimiters {
       
-      ## Normalize ".", ":", "::"
+      ## Normalize ".", ":", " : ", "::"
       "simple"
       | 
         ## Normalize the values for "simple" plus ";"

--- a/schemas/styles/csl.rnc
+++ b/schemas/styles/csl.rnc
@@ -1048,24 +1048,6 @@ div {
     ## The same as "title-delimiter" if not specified.
     attribute title-sub-delimiter { text }?,
     
-    ## Inheritable title option, specify how titles are split into "title-main" and "title-sub".
-    [ a:defaultValue = "simple" ]
-    attribute title-split {
-      
-      ## Matches "."", ":", "::", "!", "?"
-      "simple"
-      | 
-        ## Matches the values for "simple" plus ";"
-        "extended"
-      | 
-        ## Matches the values for "simple" plus "—" and ";"
-        "full"
-      | 
-        ## Matches the values for "simple" plus ";""
-        ## and "[;,] or[,:]" (see CMoS 14.91), e.g.  "Moby-Dick; or, The Whale"
-        "chicago"
-    }?,
-    
     ## Inheritable title option, specify which delimiters are normalized.
     [ a:defaultValue = "simple" ]
     attribute normalize-title-delimiters {


### PR DESCRIPTION
## Description

This removes the title-split attribute. That should be no longer necessary since titles are now objects.

Fixes #366 

(This also corrects a typo and adds an `" : "` to `normalize-title-delimiters="simple"`) 
