### PR TITLE
permit only one value on @position

### DIFF
--- a/schemas/styles/csl-choose.rnc
+++ b/schemas/styles/csl-choose.rnc
@@ -53,13 +53,11 @@ div {
     | 
       ## Tests whether the cite position matches the given positions.
       attribute position {
-        list {
-          ("first"
-           | "subsequent"
-           | "ibid"
-           | "ibid-with-locator"
-           | "near-note")+
-        }
+        "first"
+        | "subsequent"
+        | "ibid"
+        | "ibid-with-locator"
+        | "near-note"
       }
     | 
       ## Tests whether the item matches the given types.


### PR DESCRIPTION
## Description

There's no reason to allow multiple values on `@position`. This PR changes the definition of `@position` so that now only one option is permitted.

Closes #109 

## Type of change

- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] This change requires a documentation update

## Checklist

- [X] I have installed the repo [pre-commit hook](https://github.com/citation-style-language/schema/blob/master/CONTRIBUTING.md#pre-commit-hooks); if not, and I have modified any of the schema files, I have run trang and/or prettier on the files, per [CONTRIBUTING](https://github.com/citation-style-language/schema/blob/master/CONTRIBUTING.md)
- [X] I have performed a self-review of my own code
- [] I have included suggested corresponding changes to the documentation (if relevant)
