### PR TITLE
Style syntax for related variables

### DIFF
--- a/schemas/styles/csl.rnc
+++ b/schemas/styles/csl.rnc
@@ -777,10 +777,12 @@ div {
       ## Specify verbatim text.
       attribute value { text }
     | ((attribute variable { variables.numbers | variables.strings },
-        [ a:defaultValue = "long" ] attribute form { "short" | "long" })
+        [ a:defaultValue = "long" ] attribute form { "short" | "long" },
+        related?)
        | (attribute variable { variables.titles },
           [ a:defaultValue = "long" ]
-          attribute form { "short" | "long" | "sub" | "main" })?)
+          attribute form { "short" | "long" | "sub" | "main" },
+          related?)?)
 }
 # ==============================================================================
 

--- a/schemas/styles/csl.rnc
+++ b/schemas/styles/csl.rnc
@@ -414,6 +414,7 @@ div {
     attribute variable {
       list { variables.names+ }
     },
+    related?,
     affixes,
     
     ## Specify the delimiter for name lists of name variables rendered by
@@ -690,6 +691,7 @@ div {
         date.form,
         rendering-element.date.date-part.localized*)
        | (rendering-element.date.date-part.non-localized+, delimiter)),
+      related?,
       affixes,
       display,
       font-formatting,
@@ -805,7 +807,8 @@ div {
     ## Number forms: "numeric" ("4"), "ordinal" ("4th"), "long-ordinal"
     ## ("fourth"), "roman" ("iv").
     [ a:defaultValue = "numeric" ]
-    attribute form { "numeric" | "ordinal" | "long-ordinal" | "roman" }?
+    attribute form { "numeric" | "ordinal" | "long-ordinal" | "roman" }?,
+    related?
 }
 # ==============================================================================
 
@@ -848,7 +851,8 @@ div {
       delimiter,
       display,
       font-formatting,
-      rendering-element+
+      rendering-element+,
+      related?
     }
   group.attributes = notAllowed?
 }

--- a/schemas/styles/csl.rnc
+++ b/schemas/styles/csl.rnc
@@ -1136,6 +1136,11 @@ div {
   always-render = attribute always-render { xsd:boolean }?
 }
 
+## Select a related-variable
+div {
+  related = attribute related {"original" | "reviewed" }
+}
+
 ## Formatting attributes.
 div {
   affixes =

--- a/schemas/styles/csl.rnc
+++ b/schemas/styles/csl.rnc
@@ -414,7 +414,7 @@ div {
     attribute variable {
       list { variables.names+ }
     },
-    related?,
+    related,
     affixes,
     
     ## Specify the delimiter for name lists of name variables rendered by
@@ -691,7 +691,7 @@ div {
         date.form,
         rendering-element.date.date-part.localized*)
        | (rendering-element.date.date-part.non-localized+, delimiter)),
-      related?,
+      related,
       affixes,
       display,
       font-formatting,
@@ -780,11 +780,11 @@ div {
       attribute value { text }
     | ((attribute variable { variables.numbers | variables.strings },
         [ a:defaultValue = "long" ] attribute form { "short" | "long" },
-        related?)
+        related)
        | (attribute variable { variables.titles },
           [ a:defaultValue = "long" ]
           attribute form { "short" | "long" | "sub" | "main" },
-          related?)?)
+          related)?)
 }
 # ==============================================================================
 
@@ -808,7 +808,7 @@ div {
     ## ("fourth"), "roman" ("iv").
     [ a:defaultValue = "numeric" ]
     attribute form { "numeric" | "ordinal" | "long-ordinal" | "roman" }?,
-    related?
+    related
 }
 # ==============================================================================
 
@@ -852,7 +852,7 @@ div {
       display,
       font-formatting,
       rendering-element+,
-      related?
+      related
     }
   group.attributes = notAllowed?
 }
@@ -1144,7 +1144,7 @@ div {
 
 ## Select a related-variable
 div {
-  related = attribute related {"original" | "reviewed" }
+  related = attribute related {"original" | "reviewed" }?
 }
 
 ## Formatting attributes.


### PR DESCRIPTION
## Description

This adds syntax for calling related variables.
Overall, I think this should be a simple change. The only shortcoming I see is that it won't be possible to call name variables on different levels from a single `cs:names` element. (Don't know if that's a real problem.)

Closes #357 

## Type of change

- [X] New feature (non-breaking change which adds functionality)
- [X] This change requires a documentation update

## Checklist

- [X] I have installed the repo [pre-commit hook](https://github.com/citation-style-language/schema/blob/master/CONTRIBUTING.md#pre-commit-hooks); if not, and I have modified any of the schema files, I have run trang and/or prettier on the files, per [CONTRIBUTING](https://github.com/citation-style-language/schema/blob/master/CONTRIBUTING.md)
- [X] I have performed a self-review of my own code
- [] I have included suggested corresponding changes to the documentation (if relevant)
