### PR TITLE
make @form optional on cs:text with @variable

### DIFF
--- a/schemas/styles/csl.rnc
+++ b/schemas/styles/csl.rnc
@@ -777,10 +777,10 @@ div {
       ## Specify verbatim text.
       attribute value { text }
     | ((attribute variable { variables.numbers | variables.strings },
-        [ a:defaultValue = "long" ] attribute form { "short" | "long" })
+        [ a:defaultValue = "long" ] attribute form { "short" | "long" }?)
        | (attribute variable { variables.titles },
           [ a:defaultValue = "long" ]
-          attribute form { "short" | "long" | "sub" | "main" })?)
+          attribute form { "short" | "long" | "sub" | "main" }?))
 }
 # ==============================================================================
 

--- a/schemas/styles/csl.rnc
+++ b/schemas/styles/csl.rnc
@@ -777,7 +777,8 @@ div {
       ## Specify verbatim text.
       attribute value { text }
     | ((attribute variable { variables.numbers | variables.strings },
-        [ a:defaultValue = "long" ] attribute form { "short" | "long" }?)
+        [ a:defaultValue = "long" ]
+        attribute form { "short" | "long" }?)
        | (attribute variable { variables.titles },
           [ a:defaultValue = "long" ]
           attribute form { "short" | "long" | "sub" | "main" }?))


### PR DESCRIPTION
## Description

This makes `@form` optional on `cs:text` with `@variable`.


## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [X] I have installed the repo [pre-commit hook](https://github.com/citation-style-language/schema/blob/master/CONTRIBUTING.md#pre-commit-hooks); if not, and I have modified any of the schema files, I have run trang and/or prettier on the files, per [CONTRIBUTING](https://github.com/citation-style-language/schema/blob/master/CONTRIBUTING.md)
- [X] I have performed a self-review of my own code

