### PR TITLE
Add chicago page range variants

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -34,7 +34,7 @@ jobs:
     - name: Checkout Repository
       uses: actions/checkout@v2
     - name: Install dependencies
-      run: sudo apt-get install --yes trang
+      run: sudo apt-get update && sudo apt-get install --yes trang
     - name: Check schema validity
       run: trang schemas/styles/csl.rnc csl.rng && trang csl.rng csl.rnc
     - name: Check schema formatting

--- a/schemas/styles/csl.rnc
+++ b/schemas/styles/csl.rnc
@@ -765,6 +765,8 @@ div {
       | "minimal-two"
       | "minimal-oup"
       | "chicago"
+      | "chicago-15"
+      | "chicago-16"
       | "mhra"
     }?
   citation.cite-group-delimiter =


### PR DESCRIPTION
## Description

Based on discussion re: https://github.com/citation-style-language/documentation/pull/115, add `chicago-15` and `chicago-16` page range formats.

Chicago changed its page range collapse rules in 16th edition. CSL currently follows 15th edition rules. This PR adds specific formats for the two versions. For 1.0.2, `chicago` will keep its current meaning and be an alias for `chicago-15`. In 1.1 and later, it will change to be an alias for `chicago-16`.

Fixes # (issue)

## Type of change

- [X] New feature (non-breaking change which adds functionality)


