### PR TITLE
Allow cs:updated to be date or dateTime

### DIFF
--- a/schemas/styles/csl.rnc
+++ b/schemas/styles/csl.rnc
@@ -197,9 +197,8 @@ div {
     element cs:title-short { info-text }
   info.updated =
     
-    ## Specify when the style was last updated (e.g.,
-    ## "2007-10-26T21:32:52+02:00")
-    element cs:updated { xsd:dateTime }
+    ## Specify when the style was last updated (e.g., "2007-10-26" or "2007-10-26T21:32:52+02:00")
+    element cs:updated { xsd:dateTime | xsd:date }
   info-text =
     attribute xml:lang { xsd:language }?,
     text


### PR DESCRIPTION
## Description

Suggested by @cormacrelf
> It's a small pain point but the format allowed in cs:updated is an xsd:dateTime when it should probably have been an xsd:date. One shouldn't have to look up xsd:dateTime and type in a bunch of zeroes and colons in the right order to make CSL validate. For a field that really, really does not need timestamp precision.
>
>Simple solution: allow either. Then people can update with 2020-05-19, much more human friendly.

I don't see much issue with allowing just a date. Would that interfere with anything @dstillman?

Re: https://github.com/citation-style-language/documentation/issues/129

## Type of change

Please delete options that are not relevant.

- [X] New feature (non-breaking change which adds functionality)
- [X] This change requires a documentation update