### PR TITLE
bug fix for 1.0/1.0.2: make @form optional again

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,9 @@ More info at https://rhodesmill.org/brandon/2012/one-sentence-per-line/
 This is the official repository for schemas describing the Citation Style Language (CSL).
 Current schemas include:
 
-* CSL schema - describes CSL style and locale XML files
-* CSL-JSON schema - describes a commonly used JSON data model for storing CSL processor input
+* [CSL schema](#csl-schema) - describes CSL style and locale XML files
+* [CSL-JSON schema](#csl-json-schema) -
+  describes a commonly used JSON data model for storing CSL processor input
   (such as bibliographic metadata).
 
 For more information about CSL, visit <https://citationstyles.org>.

--- a/schemas/styles/csl.rnc
+++ b/schemas/styles/csl.rnc
@@ -634,8 +634,10 @@ div {
     | 
       ## Specify verbatim text.
       attribute value { text }
-    | (attribute variable { variables.standard },
-       [ a:defaultValue = "long" ] attribute form { "short" | "long" })?
+    | (
+       ## Select a variable.
+       attribute variable { variables.standard },
+       [ a:defaultValue = "long" ] attribute form { "short" | "long" }?)
 }
 # ==============================================================================
 


### PR DESCRIPTION
With this change `@form` is again optional. With that change Chicago-author-date.csl validates successfully again. (I don't know if there are other leftovers from 1.1 in the 1.0 branch.)