### PR TITLE
Bugfixes for 1.0.2

### DIFF
--- a/schemas/styles/csl-variables.rnc
+++ b/schemas/styles/csl-variables.rnc
@@ -83,8 +83,6 @@ div {
     | # Short title forms. Will be removed in CSL 1.1
       "title-short"
     | "container-title-short"
-
-
   
   ## String variables
   variables.strings =

--- a/schemas/styles/csl-variables.rnc
+++ b/schemas/styles/csl-variables.rnc
@@ -80,6 +80,11 @@ div {
     | "reviewed-title"
     | "title"
     | "volume-title"
+    | # Short title forms. Will be removed in CSL 1.1
+      "title-short"
+    | "container-title-short"
+
+
   
   ## String variables
   variables.strings =

--- a/schemas/styles/csl.rnc
+++ b/schemas/styles/csl.rnc
@@ -634,8 +634,10 @@ div {
     | 
       ## Specify verbatim text.
       attribute value { text }
-    | (attribute variable { variables.standard },
-       [ a:defaultValue = "long" ] attribute form { "short" | "long" })?
+    | (
+       ## Select a variable.
+       attribute variable { variables.standard },
+       [ a:defaultValue = "long" ] attribute form { "short" | "long" }?)
 }
 # ==============================================================================
 


### PR DESCRIPTION
This makes `@form` optional again. With this change 1.0 styles can again be validated.

Edit: This also re-adds `title-short` and `container-title-short`.

Question: How can I now check how that compares to 1.0.1?