### PR TITLE
Restore titles allowing simple string values

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,19 +1,24 @@
 ---
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v2.5.0
+    rev: v4.0.1
     hooks:
       - id: check-merge-conflict
-  - repo: https://github.com/prettier/prettier
-    rev: 2.0.5
+      - id: check-json
+  - repo: https://github.com/pre-commit/mirrors-prettier
+    rev: v2.3.2
     hooks:
       - id: prettier
-        types: [json,yaml]
+        name: Prettier JSON
+        types: [json]
+      - id: prettier
+        name: Prettier YAML
+        types: [yaml]
   - repo: local
     hooks:
       - id: rnc-format-validate
         name: Check rnc schema files
         entry: tools/rnc-validate-format.py
-        args: ['--commit']
+        args: ["--commit"]
         language: python
         files: ^schemas/styles/csl*.rnc$

--- a/schemas/input/csl-data.json
+++ b/schemas/input/csl-data.json
@@ -10,8 +10,11 @@
   "definitions": {
     "title-variable": {
       "title": "Title variable",
-      "description": "Titles are represented as an object.",
-      "$ref": "#/definitions/title-object"
+      "description": "Titles are represented as a string or as an object.",
+      "anyOf": [
+        { "$ref": "#/definitions/rich-text-string" },
+        { "$ref": "#/definitions/title-object" }
+      ]
     },
     "title-object": {
       "title": "Title Object",
@@ -72,11 +75,6 @@
       "title": "Rich Text String",
       "description": "A string that may include sub-string formatting for bold, italic, subscript, superscript, math, etc. The accompanying `csl-rich-text.yaml` schema defines experimental support for this in CSL JSON input.",
       "type": "string"
-    },
-    "title-string": {
-      "title": "Title String",
-      "description": "Titles are a primary example of rich text strings in CSL.",
-      "$ref": "#/definitions/rich-text-string"
     },
     "edtf-string": {
       "title": "EDTF date string",


### PR DESCRIPTION
Targeting v1.1.

## Description

Fixes title variables not allowing plain strings, but being documented being string or title-object. There was a `title-string` definition but it was unused, so title-variable is now an anyOf union.

See https://github.com/citation-style-language/schema/pull/393#event-4911844030 for general discussion of deprecating instead of outright removing.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [X] I have installed the repo [pre-commit hook](https://github.com/citation-style-language/schema/blob/master/CONTRIBUTING.md#pre-commit-hooks); if not, and I have modified any of the schema files, I have run trang and/or prettier on the files, per [CONTRIBUTING](https://github.com/citation-style-language/schema/blob/master/CONTRIBUTING.md)
- [X] I have performed a self-review of my own code
- [X] I have included suggested corresponding changes to the documentation (if relevant)
