### PR TITLE
Restore title-short variables for 1.0 compat

### DIFF
--- a/schemas/input/csl-data.json
+++ b/schemas/input/csl-data.json
@@ -573,8 +573,16 @@
         "collection-title": {
           "$ref": "#/definitions/title-variable"
         },
+        "collection-title-short": {
+          "description": "[Deprecated - use `collection-title` with a `short` key",
+          "type": "string"
+        },
         "container-title": {
           "$ref": "#/definitions/title-variable"
+        },
+        "container-title-short": {
+          "description": "[Deprecated - use `container-title` with a `short` key",
+          "type": "string"
         },
         "dimensions": {
           "type": "string"
@@ -712,6 +720,10 @@
         },
         "title": {
           "$ref": "#/definitions/title-variable"
+        },
+        "title-short": {
+          "description": "[Deprecated - use `title` with a `short` key",
+          "type": "string"
         },
         "URL": {
           "type": "string"


### PR DESCRIPTION
## Description

Like #396. Again see commentary in https://github.com/citation-style-language/schema/pull/393 where these were added back to the RNC. Adding back to the JSON schema is a slightly different proposition, but if anything I think it's a stronger one. This addresses the durability of systems that produce CSL-JSON for consumption by a processor. I estimate these are significantly less nimble than style authoring, particularly because these are systems that are essentially never written by hand, whose output is never seen by human eyes, and whose errors require much deeper debugging. Even where they are (CSL test suite), that's a lot of work to update. CSL processors, *including newly written ones*, are going to have to support CSL-JSON 1.0 for a long while yet, so I think this should be reflected in deprecation rather than removal.

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [X] I have installed the repo [pre-commit hook](https://github.com/citation-style-language/schema/blob/master/CONTRIBUTING.md#pre-commit-hooks); if not, and I have modified any of the schema files, I have run trang and/or prettier on the files, per [CONTRIBUTING](https://github.com/citation-style-language/schema/blob/master/CONTRIBUTING.md)
- [X] I have performed a self-review of my own code
- [X] I have included suggested corresponding changes to the documentation (if relevant)
