### PR TITLE
Revert new date object format

### DIFF
--- a/schemas/input/csl-data.json
+++ b/schemas/input/csl-data.json
@@ -86,7 +86,7 @@
     },
     "date-object-v2": {
       "title": "Date Object (v2)",
-      "description": "Supprts literal only, for now",
+      "description": "Supports literal only, for now",
       "oneOf": [
         {
           "type": "object",


### PR DESCRIPTION
## Description

This reverts the JSON version of the EDTF date object that was introduced in #301. I read over that PR and the discussion. I don't think we need it at all, and it's better that it is deleted now.

If you want to completely remove the old format, we can also do that. I have drafted this PR to make that easy if necessary, without losing the one feature I think it has going for it (`"issued": { "literal": "Han Dynasty" }`). I have also removed the `{ "edtf": "..." }` object format, because I don't believe that offered any utility, there are no circumstances under which you would want to have an edtf alongside any other property from that object.

## Why?

I see the only options for the date object as either:

- preserve the old date object (`date-parts` & friends) in its entirety for compatibility, preserve it via oneOf EDTF / old
- OR, delete it and make CSL JSON v2.0 with only EDTF, since people are going to have to adjust code for the breaking change anyway.

I do not see the value in making a new date object whose only purpose is to replicate EDTF functionality in JSON. I get that it does what it says on the tin ("harmonises" the json/yaml input and EDTF) but in reality it is just a new, incompatible format that the PR itself recognised would have to be removed in favour of EDTF at some point. If it represents exactly the dates that EDTF represents, but does not carry any of the benefits of standardisation, e.g. being known to be in the well-defined ISO calendar, having literally any existing implementations, etc, then I do not see the point at all. If you want a data model for EDTF, simply read the EDTF specification. If you wanted a more computer-friendly format, or a more human friendly format (not sure?), the existing EDTF standard is better for both humans and computers.

## What about harmonising with EDTF?

The thing that actually needed harmonising was CSL, not so much CSL-JSON. There are nevertheless some extensions to consider for CSL-JSON, but they do not include reproducing the functionality of EDTF. I have a number of suggestions based on my experience implementing the EDTF spec, I'll file separate issues for that. (Edit: https://github.com/citation-style-language/documentation/issues/145)

(For history, ref #284 as well)