### PR TITLE
Strip protocol

### DIFF
--- a/schemas/styles/csl.rnc
+++ b/schemas/styles/csl.rnc
@@ -853,6 +853,7 @@ div {
     style.demote-non-dropping-particle,
     style.initialize-with-hyphen,
     style.page-range-format,
+    style.strip-url-protocol,
     title-inheritable-options,
     names-inheritable-options,
     name-inheritable-options,


### PR DESCRIPTION
## Description

Adds a style attribute specifying that `https://` and `http://` should be stripped from rendered URLs. 

Fixes [# (issue)](https://github.com/citation-style-language/schema/issues/395)

## Type of change

- [X] New feature (non-breaking change which adds functionality)
- [X] This change requires a documentation update

## Checklist

- [X] I have installed the repo [pre-commit hook](https://github.com/citation-style-language/schema/blob/master/CONTRIBUTING.md#pre-commit-hooks); if not, and I have modified any of the schema files, I have run trang and/or prettier on the files, per [CONTRIBUTING](https://github.com/citation-style-language/schema/blob/master/CONTRIBUTING.md)
- [X] I have performed a self-review of my own code
- [X] I have included suggested corresponding changes to the documentation (if relevant)
