### PR TITLE
Add missing type field to JSON Schema csl-data

### DIFF
--- a/schemas/input/csl-data.json
+++ b/schemas/input/csl-data.json
@@ -463,6 +463,7 @@
     "name-variable": {
       "anyOf": [
         {
+          "type": "object",
           "properties": {
             "family": {
               "type": "string"
@@ -501,6 +502,7 @@
       "description": "The CSL input model supports two different date representations: an EDTF string (preferred), and a more structured alternative.",
       "anyOf": [
         {
+          "type": "object",
           "properties": {
             "date-parts": {
               "type": "array",


### PR DESCRIPTION
## Description

The JSON Schema csl-data.json misses recommended field `type` at two places. Most validators can make use of the schemas as they are but at least ajv with https://ajv.js.org/strict-mode.html complains.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [X] I have installed the repo [pre-commit hook](https://github.com/citation-style-language/schema/blob/master/CONTRIBUTING.md#pre-commit-hooks); if not, and I have modified any of the schema files, I have run trang and/or prettier on the files, per [CONTRIBUTING](https://github.com/citation-style-language/schema/blob/master/CONTRIBUTING.md)
- [X] I have performed a self-review of my own code
- [X] I have included suggested corresponding changes to the documentation (if relevant)
