### PR TITLE
Add validation for et-al-min and et-al-use-first

### DIFF
--- a/schemas/styles/csl.sch
+++ b/schemas/styles/csl.sch
@@ -11,5 +11,8 @@
     <sch:rule context="/cs:style/cs:macro">
       <sch:assert test="count(/cs:style/cs:macro/@name[. = current()/@name]) = 1">This macro does not have a unique name.</sch:assert>
     </sch:rule>
+    <sch:rule context="*[@et-al-min]">
+      <sch:assert test="number(current()/@et-al-min) gt number(current()/@et-al-use-first)">et-al-min must be greater than et-al-use-first.</sch:assert>
+    </sch:rule>
   </sch:pattern>
 </sch:schema>


### PR DESCRIPTION
## Description

See discussion in https://github.com/citation-style-language/documentation/pull/141

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Variable addition (adds a new variable or type string)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] This change requires a documentation update

## Checklist

- [ ] I have installed the repo [pre-commit hook](https://github.com/citation-style-language/schema/blob/master/CONTRIBUTING.md#pre-commit-hooks); if not, and I have modified any of the schema files, I have run trang and/or prettier on the files, per [CONTRIBUTING](https://github.com/citation-style-language/schema/blob/master/CONTRIBUTING.md)
- [X] I have performed a self-review of my own code
- [X] I have included suggested corresponding changes to the documentation (if relevant)
