### PR TITLE
Allow multiple citation templates

### DIFF
--- a/schemas/styles/csl.rnc
+++ b/schemas/styles/csl.rnc
@@ -374,17 +374,31 @@ div {
 
 ## cs:citation and cs:bibliography
 div {
+  style.citation.element = citation.options, sort?, citation.layout
   style.citation =
     
     ## Use to describe the formatting of citations.
-    element cs:citation { citation.options, sort?, citation.layout }
+    ## A "default" mode template is required.
+    element cs:citation {
+      attribute mode { "default" },
+      style.citation.element
+    },
+    element cs:citation {
+      attribute mode { style.citation.modes },
+      style.citation.element
+    }*
+  
+  ## TODO what else? Arbitrary extension?
+  style.citation.modes = "in-text" | "suppress-author"
+  
+  ## TODO revert this
   style.intext =
     
     ## Defines the author-only rendering for assembly of a textual citations
     ## (for example, "Doe [3]" or "Doe (2018)"), where the output expectations
     ## for in-text authors are different than the default citation rendering;
     ## for example, in APA, or numeric styles.
-    element cs:intext { citation.options, sort?, citation.layout }
+    element cs:intext { style.citation.element }
   style.bibliography =
     
     ## Use to describe the formatting of the bibliography.


### PR DESCRIPTION
Per discussion starting at https://github.com/citation-style-language/schema/pull/173#issuecomment-1142418272 (but also preceding it above), this is an alternative to #193.

The idea is to revert that, and replace it with a more general solution: multiple citation templates.

Example:

```xml
<citation mode="default">
...
</citation>
<citation mode="in-text">
...
</citation>
<citation mode="bib-entry">
...
</citation>
```

## Notes

1. The primary use case that both this and #193 are supporting is major styles like APA which require different author list formatting in text and in parens. In that case, one must specify those details in the style for it to work as expected. 
2. That last example isn't supported in the initial commit, but also shows a wrinkle; really there we want to say to use the bibliography template for rendering the citation.
3. Also larger context: we could imagine also multiple bibliography elements, for multi-section bibs and such, but that's out-of-scope here.
4. I haven't figured out how to revert #193 in git, but if not, it's easy enough to just remove the lines here.
5. Another approach would be multiple layouts within a single citation. I've not thought about the details enough to know ATM which is better.

## Related questions

Many existing citeprocs (for js, elisp, haskell, and rust) already support implicit "suppress-author" and "in-text" commands.

Thoughts on how to handle this?

I see a few options, which aren't necessarily mutually-exclusive:

1. document the logic for these (both suppress-author and in-text)
3. use 1 to automate style updates
4. require 1.1/2.0-compliant processors to support 1 also (which means works with 1.0 also)
6. leave 1 optional

CC @bwiernik @denismaier @andras-simonyi @jgm @zepinglee @cormacrelf

If there are objections, I can also just close this PR. But I wanted to discuss something concrete.