### PR TITLE
input: Convert root into object, require version

### DIFF
--- a/schemas/input/csl-data.json
+++ b/schemas/input/csl-data.json
@@ -99,8 +99,7 @@
     "edtf-string": {
       "title": "EDTF date string",
       "description": "CSL input supports EDTF, levels 0 and 1.",
-      "type": "string",
-      "pattern": "^[0-9-%~X?./]{4,}$"
+      "type":"string"
     },
     "date-object-v2": {
       "title": "Date Object (v2)",

--- a/schemas/input/csl-data.json
+++ b/schemas/input/csl-data.json
@@ -2,18 +2,38 @@
   "title": "CSL JSON/YAML",
   "description": "JSON schema for CSL input data",
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "https://resource.citationstyles.org/schema/latest/input/json/csl-data.json",
-  "type": "array",
-  "items": {
-    "$ref": "#/definitions/refitem"
+  "$id": "https://resource.citationstyles.org/schema/v1.1/input/json/csl-data.json",
+  "type": "object",
+  "required": ["references", "version"],
+  "properties": {
+    "version": {
+      "type": "number",
+      "enum": [1.1]
+    },
+    "title": {
+      "type": "string"
+    },
+    "description": {
+      "type": "string"
+    },
+    "references": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/refitem"
+      }
+    }
   },
   "definitions": {
     "title-variable": {
       "title": "Title variable",
       "description": "Titles are represented as a string or as an object.",
       "anyOf": [
-        { "$ref": "#/definitions/rich-text-string" },
-        { "$ref": "#/definitions/title-object" }
+        {
+          "$ref": "#/definitions/rich-text-string"
+        },
+        {
+          "$ref": "#/definitions/title-object"
+        }
       ]
     },
     "title-object": {
@@ -90,7 +110,11 @@
           "type": "object",
           "title": "Literal Date",
           "description": "A date that should be passed through to the processor as is; for dates that cannot be represented in EDTF.",
-          "examples": [{ "literal": "Han Dynasty" }],
+          "examples": [
+            {
+              "literal": "Han Dynasty"
+            }
+          ],
           "properties": {
             "literal": {
               "type": "string"

--- a/tests/schemas/input/test_json.py
+++ b/tests/schemas/input/test_json.py
@@ -84,10 +84,15 @@ def test_schema_is_valid(json_schema):
 
 
 def test_basic_data_schema_validates(csl_data_validator):
-    csl = [{
-        'id': 'example-id',
-        'type': 'report',
-    }]
+    csl = {
+        'version': 1.1,
+        'references': [
+            {
+               'id': 'example-id',
+               'type': 'report',
+            }
+        ]
+    }
     csl_data_validator.validate(csl)
 
 
@@ -129,14 +134,19 @@ def test_citation_schema_compound_locator_validates(csl_citation_validator):
     csl_citation_validator.validate(cite)
 
 def test_basic_data_schema_with_author_validates(csl_data_validator):
-    csl = [{
-        "id": "example-id",
-        "type": "report",
-        "author": [
-            {"given": "Jane", "family": "Roe"},
-            {"institution": "ACME Corporation"}
+    csl =  {
+        'version': 1.1,
+        'references': [
+           {
+                "id": "example-id",
+                "type": "report",
+                "author": [
+                    {"given": "Jane", "family": "Roe"},
+                    {"institution": "ACME Corporation"}
+               ]
+           }
         ]
-    }]
+    }
     csl_data_validator.validate(csl)
 
 


### PR DESCRIPTION
Convert the root of schema into an object with metadata, and a required
`version` property.
    
Include optional `title` and `description` properties.

While I'm at it, also removing the edtf regex on a separate commit.
    
Close #319

-------

## Examples

Aside from this being a better, forward-looking, design, it's also more consistent with the pandoc YAML model.

The below shows this change, but in larger context of the other changes suggested in the `v1.1` branch; notably with dates and titles.

An example, validated against the schema in YAML, with EDTF dates (though the regex here doesn't cover the date-time example ATM, so the validator throws an error on that property; really need a proper EDTF regex, which is not my skillset, or maybe just drop the constraint for now; see #421).

```yaml
---
version: 1.1
description: An example CSL YAML 1.1 file
references:
  - type: book
    id: test1
    issued: '2020'
    title: 
      main: Title
      sub:
        - Subtitle
    author:
      - given: Jane
        family: Doe
  - type: article-journal
    id: test2
    issued: 2020-07/2020-08
    title: Simple title
    author:
      - given: John
        family: Smith
  - type: post
    id: test3
    title: “Most kids are fine!”, people say
    issued: 2022-06-02T01:57:29Z
    URL: https://twitter.com/zeynep/status/1532356192567189506
```

... and converted to JSON:

```json
{
  "version": 1.1,
  "description": "An example CSL YAML 1.1 file",
  "references": [
    {
      "type": "book",
      "id": "test1",
      "issued": "2020",
      "title": {
        "main": "Title",
        "sub": [
          "Subtitle"
        ]
      },
      "author": [
        {
          "given": "Jane",
          "family": "Doe"
        }
      ]
    },
    {
      "type": "article-journal",
      "id": "test2",
      "issued": "2020-07/2020-08",
      "title": "Simple title",
      "author": [
        {
          "given": "John",
          "family": "Smith"
        }
      ]
    },
    {
      "type": "post",
      "id": "test3",
      "title": "“Most kids are fine!”, people say",
      "issued": "2022-06-02T01:57:29.000Z",
      "URL": "https://twitter.com/zeynep/status/1532356192567189506"
    }
  ]
}
```

... with schema-backed completion in VSCode:

![Screenshot from 2022-06-01 21-09-33](https://user-images.githubusercontent.com/1134/171526441-6b509691-525a-4472-9a1a-33ed26a2a45c.png)

Seems this ecosystem has evolved in the past two years. Once we settle on a final version, we really need to get this schema published on https://www.schemastore.org/json/, which makes editor support all the easier.

cc @jgm @bwiernik @denismaier @cormacrelf @retorquere