### PR TITLE
input: Add 'format' property for edtf dates

### DIFF
--- a/schemas/input/csl-data.json
+++ b/schemas/input/csl-data.json
@@ -99,7 +99,8 @@
     "edtf-string": {
       "title": "EDTF date string",
       "description": "CSL input supports EDTF, levels 0 and 1.",
-      "type":"string"
+      "type":"string",
+      "format": "edtf/level-1+season-intervals"
     },
     "date-object-v2": {
       "title": "Date Object (v2)",


### PR DESCRIPTION
This allow use of an edtf.js-based validator on the dates.

https://github.com/retorquere/json-schema-edtf

The json schema spec says tools should ignore the property
if they don't know what to do with its value.

Close #421
