### PR TITLE
use absolute URI when referencing CSL schema

### DIFF
--- a/schemas/input/csl-citation.json
+++ b/schemas/input/csl-citation.json
@@ -28,7 +28,7 @@
                         ]
                     },
                     "itemData": {
-                        "$ref": "csl-data.json#/items" 
+                        "$ref": "https://resource.citationstyles.org/schema/v1.0/input/json/csl-data.json#/items" 
                     },
                     "prefix": {
                         "type": "string" 


### PR DESCRIPTION
## Description

The JSON Schema for a Cite Item references the CSL Data schema (with `$ref`) using a relative URI, `csl-data.json`. However, the `$id` for the CSL Data schema is an absolute URI, which means that attempts to validate data against the Cite Item schema will typically fail without a workaround.

This PR changes the reference to the CSL Data schema to use its absolute URI instead of a relative one.

Fixes #427

## Type of change

Bug fix (non-breaking change which fixes an issue)

## Checklist

- [X] I have installed the repo [pre-commit hook](https://github.com/citation-style-language/schema/blob/master/CONTRIBUTING.md#pre-commit-hooks); if not, and I have modified any of the schema files, I have run trang and/or prettier on the files, per [CONTRIBUTING](https://github.com/citation-style-language/schema/blob/master/CONTRIBUTING.md)
- [X] I have performed a self-review of my own code
- [X] I have included suggested corresponding changes to the documentation (if relevant)
