### PR TITLE
Add ARXIV variable

### DIFF
--- a/schemas/input/csl-data.json
+++ b/schemas/input/csl-data.json
@@ -378,6 +378,9 @@
       "part-title": {
         "type": "string"
       },
+      "ARXIV": {
+        "type": "string"
+      },
       "PMCID": {
         "type": "string"
       },

--- a/schemas/styles/csl-variables.rnc
+++ b/schemas/styles/csl-variables.rnc
@@ -114,6 +114,7 @@ div {
     | "note"
     | "original-publisher"
     | "original-publisher-place"
+    | "ARXIV"
     | "PMCID"
     | "PMID"
     | "publisher"


### PR DESCRIPTION
## Description
This adds an identifier for [arXiv](https://arxiv.org/) "ARXIV" similar to PM(C)ID, DOI or ISBN.

See https://github.com/typst/hayagriva/pull/326.


## Type of change

- [X] Variable addition (adds a new variable or type string)

## Checklist

- [X] I have installed the repo [pre-commit hook](https://github.com/citation-style-language/schema/blob/master/CONTRIBUTING.md#pre-commit-hooks); if not, and I have modified any of the schema files, I have run trang and/or prettier on the files, per [CONTRIBUTING](https://github.com/citation-style-language/schema/blob/master/CONTRIBUTING.md)
- [X] I have performed a self-review of my own code
- [X] I have included suggested corresponding changes to the documentation (if relevant)
